### PR TITLE
Modernise, standardise, and harden easysnowdata (v0.0.22) [SUPERSEDED]

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,53 +3,30 @@ on:
     pull_request:
         branches:
             - main
-            - master
 
 jobs:
-    deploy:
+    build:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
 
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip
-                  pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL pyproj
-            - name: Test GDAL installation
+                  pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL
+
+            - name: Install package and docs dependencies
               run: |
-                  python -c "from osgeo import gdal"
-                  gdalinfo --version
-            - name: Install dependencies
-              run: |
-                  pip install --no-cache-dir Cython
-                  pip install -r requirements.txt -r requirements_dev.txt
-                  pip install .
-            - name: Discover typos with codespell
-              run: codespell --skip="*.csv,*.geojson,*.json,*.js,*.html,*cff,*.pdf,./.git" --ignore-words-list="aci,acount,hist"
-            - name: PKG-TEST
-              run: |
-                  python -m unittest discover tests/
+                  pip install -e .
+                  pip install mkdocs mkdocs-material mkdocstrings mkdocstrings-python \
+                      pymdown-extensions pygments mkdocs-jupyter \
+                      mkdocs-git-revision-date-localized-plugin
+
             - name: Build docs
-              run: |
-                  mkdocs build
-            # - name: Deploy to Netlify
-            #   uses: nwtgck/actions-netlify@v2.0
-            #   with:
-            #       publish-dir: "./site"
-            #       production-branch: main
-
-            #       github-token: ${{ secrets.GITHUB_TOKEN }}
-            #       deploy-message: "Deploy from GitHub Actions"
-            #       enable-pull-request-comment: true
-            #       enable-commit-comment: false
-            #       overwrites-pull-request-comment: true
-            #   env:
-            #       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-            #       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-            #   timeout-minutes: 10
-
+              run: mkdocs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,27 +3,29 @@ on:
     push:
         branches:
             - main
-            - master
+
 jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
             - uses: actions/setup-python@v5
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
 
-            - name: Install dependencies
+            - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip
-                  pip install --user --no-cache-dir Cython
-                  pip install --user -r requirements.txt -r requirements_dev.txt
-                  pip install .
-            # - name: Discover typos with codespell
-            #   run: |
-            #       codespell --skip="*.csv,*.geojson,*.json,*.js,*.html,*cff,./.git" --ignore-words-list="aci,hist"
-            - name: PKG-TEST
-              run: |
-                  python -m unittest discover tests/
-            - run: mkdocs gh-deploy --force
+                  pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL
 
+            - name: Install package and docs dependencies
+              run: |
+                  pip install -e .
+                  pip install mkdocs mkdocs-material mkdocstrings mkdocstrings-python \
+                      pymdown-extensions pygments mkdocs-jupyter \
+                      mkdocs-git-revision-date-localized-plugin
+
+            - run: mkdocs gh-deploy --force

--- a/easysnowdata/__init__.py
+++ b/easysnowdata/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = "Eric Gagliano"
 __email__ = "egagli@uw.edu"
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 __all__ = [
     "utils",
     "remote_sensing",

--- a/easysnowdata/automatic_weather_stations.py
+++ b/easysnowdata/automatic_weather_stations.py
@@ -40,9 +40,7 @@ _STATION_GEOJSON_URL = (
 _STATION_DATA_BASE_URL = (
     "https://raw.githubusercontent.com/egagli/snotel_ccss_stations/main/data/"
 )
-_ARCHIVE_URL = (
-    "https://github.com/egagli/snotel_ccss_stations/raw/main/data/all_station_data.tar.lzma"
-)
+_ARCHIVE_URL = "https://github.com/egagli/snotel_ccss_stations/raw/main/data/all_station_data.tar.lzma"
 
 
 class StationCollection:
@@ -147,13 +145,9 @@ class StationCollection:
             all_stations_gdf = all_stations_gdf.sort_values("dist_km")
 
         self.all_stations = all_stations_gdf
-        _logger.info(
-            "Loaded %d stations into all_stations.", len(self.all_stations)
-        )
+        _logger.info("Loaded %d stations into all_stations.", len(self.all_stations))
 
-    def choose_stations(
-        self, stations_input: gpd.GeoDataFrame | str | list
-    ) -> None:
+    def choose_stations(self, stations_input: gpd.GeoDataFrame | str | list) -> None:
         """Select a subset of stations by code string, list of codes, or GeoDataFrame.
 
         Parameters
@@ -295,12 +289,14 @@ class StationCollection:
             for station in tqdm.tqdm(self.stations.index, desc=variable):
                 try:
                     url = f"{_STATION_DATA_BASE_URL}{station}.csv"
-                    tmp = pd.read_csv(
-                        url, index_col="datetime", parse_dates=True
-                    )[variable]
+                    tmp = pd.read_csv(url, index_col="datetime", parse_dates=True)[
+                        variable
+                    ]
                     station_dict[station] = tmp
                 except Exception as exc:
-                    _logger.warning("Failed to retrieve %s for %s: %s", variable, station, exc)
+                    _logger.warning(
+                        "Failed to retrieve %s for %s: %s", variable, station, exc
+                    )
 
             station_df = pd.DataFrame.from_dict(station_dict).loc[start_date:end_date]
             setattr(self, variable, station_df)
@@ -323,9 +319,7 @@ class StationCollection:
         ds.coords["DOWY"] = ("time", pd.to_datetime(ds.time).map(datetime_to_DOWY))
 
         self.data = ds
-        _logger.info(
-            "Loaded %s for %d stations.", variables, len(self.stations)
-        )
+        _logger.info("Loaded %s for %d stations.", variables, len(self.stations))
 
     def get_entire_data_archive(
         self, refresh: bool = True, temp_dir: str = "/tmp/"
@@ -356,9 +350,7 @@ class StationCollection:
 
         if not compressed_path.exists() or refresh:
             _logger.info("Downloading archive to %s …", compressed_path)
-            subprocess.run(
-                ["wget", "-q", "-P", temp_dir, _ARCHIVE_URL], check=True
-            )
+            subprocess.run(["wget", "-q", "-P", temp_dir, _ARCHIVE_URL], check=True)
 
         if not decompressed_dir.exists() or refresh:
             _logger.info("Decompressing archive …")

--- a/easysnowdata/hydroclimatology.py
+++ b/easysnowdata/hydroclimatology.py
@@ -41,8 +41,11 @@ _logger = logging.getLogger(__name__)
 
 @requires_earthengine
 def get_huc_geometries(
-        bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
-        huc_level: str = "02",
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    huc_level: str = "02",
 ) -> gpd.GeoDataFrame:
     """
     Retrieves Hydrologic Unit Code (HUC) geometries within a specified bounding box and HUC level.
@@ -84,7 +87,7 @@ def get_huc_geometries(
     https://doi.org/10.3133/tm11A3
     """
 
-    ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
+    ee.Initialize(opt_url="https://earthengine-highvolume.googleapis.com")
 
     # Convert bounding box to feature collection to use as region for querying HUC geometries
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
@@ -105,7 +108,7 @@ def get_huc_geometries(
     huc_gdf = huc_gdf[
         [
             "name",
-            f'huc{huc_level.lstrip("0")}',
+            f"huc{huc_level.lstrip('0')}",
             "areasqkm",
             "states",
             "tnmid",
@@ -113,19 +116,25 @@ def get_huc_geometries(
         ]
     ]
 
-    huc_gdf.attrs = {"Data citation": "Jones, K.A., Niknami, L.S., Buto, S.G., and Decker, D., 2022, Federal standards and procedures for the national Watershed Boundary Dataset (WBD) (5 ed.): U.S. Geological Survey Techniques and Methods 11-A3, 54 p., https://doi.org/10.3133/tm11A3"}
-    
+    huc_gdf.attrs = {
+        "Data citation": "Jones, K.A., Niknami, L.S., Buto, S.G., and Decker, D., 2022, Federal standards and procedures for the national Watershed Boundary Dataset (WBD) (5 ed.): U.S. Geological Survey Techniques and Methods 11-A3, 54 p., https://doi.org/10.3133/tm11A3"
+    }
+
     return huc_gdf
 
+
 def get_hydroBASINS(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
     level: int = 5,
 ) -> gpd.GeoDataFrame:
     """
     Retrieves HydroATLAS sub-basin boundaries at specified hierarchical level.
 
     This function downloads and loads vectorized polygon layers depicting sub-basin boundaries
-    from the HydroATLAS database via figshare. It provides consistently sized and hierarchically 
+    from the HydroATLAS database via figshare. It provides consistently sized and hierarchically
     nested sub-basins at different scales, supported by Pfafstetter coding for catchment topology analysis.
 
     Parameters
@@ -144,12 +153,12 @@ def get_hydroBASINS(
     Examples
     --------
     Get level 5 sub-basins for all regions...
-    
+
     >>> basins = get_hydroBASINS()
     >>> basins.plot()
 
     Get level 6 sub-basins for a specific region...
-    
+
     >>> bbox = (-121.94, 46.72, -121.54, 46.99)
     >>> regional_basins = get_hydroBASINS(bbox_input=bbox, level=6)
     >>> regional_basins.plot()
@@ -160,25 +169,27 @@ def get_hydroBASINS(
     making it more efficient than downloading individual regional HydroBASINS files.
 
     Data citation:
-    Linke, S., Lehner, B., Ouellet Dallaire, C., Ariwi, J., Grill, G., Anand, M., Beames, P., 
+    Linke, S., Lehner, B., Ouellet Dallaire, C., Ariwi, J., Grill, G., Anand, M., Beames, P.,
     Burchard-Levine, V., Maxwell, S., Moidu, H., Tan, F., Thieme, M. (2019). Global hydro-
-    environmental sub-basin and river reach characteristics at high spatial resolution. 
+    environmental sub-basin and river reach characteristics at high spatial resolution.
     Scientific Data 6: 283. doi: 10.1038/s41597-019-0300-6
     """
-    
+
     # Validate level parameter
     if level < 1 or level > 12:
         raise ValueError(f"Level must be between 1 and 12, got {level}")
-    
+
     # Convert bbox to GeoDataFrame if provided
-    bbox_gdf = convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
-    
+    bbox_gdf = (
+        convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    )
+
     # Construct URL and layer name
-    url = 'https://figshare.com/ndownloader/files/20082137/BasinATLAS_Data_v10.gdb.zip'
+    url = "https://figshare.com/ndownloader/files/20082137/BasinATLAS_Data_v10.gdb.zip"
     layer_name = f"BasinATLAS_v10_lev{level:02d}"
-    
+
     _logger.info("Loading HydroATLAS level {level} basins...")
-    
+
     # Load the data with optional spatial masking
     if bbox_gdf is not None:
         basins_gdf = gpd.read_file("zip+" + url, mask=bbox_gdf, layer=layer_name)
@@ -196,15 +207,19 @@ def get_hydroBASINS(
 
     return basins_gdf
 
+
 def get_grdc_major_river_basins_of_the_world(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Retrieves GRDC Major River Basins of the World dataset.
 
-    This function downloads and loads the Global Runoff Data Centre's (GRDC) Major River Basins 
-    dataset, which contains 520 river/lake basins considered major in size or hydro-political 
-    importance. The basins include both exorheic drainage (flowing to oceans) and endorheic 
+    This function downloads and loads the Global Runoff Data Centre's (GRDC) Major River Basins
+    dataset, which contains 520 river/lake basins considered major in size or hydro-political
+    importance. The basins include both exorheic drainage (flowing to oceans) and endorheic
     drainage (inland sinks/lakes) systems.
 
     Parameters
@@ -232,22 +247,24 @@ def get_grdc_major_river_basins_of_the_world(
 
     Notes
     -----
-    This dataset incorporates data from HydroSHEDS database which is © World Wildlife Fund, Inc. 
+    This dataset incorporates data from HydroSHEDS database which is © World Wildlife Fund, Inc.
     (2006-2013) and has been used under license.
 
     Data citation:
-    GRDC (2020): GRDC Major River Basins. Global Runoff Data Centre. 2nd, rev. ed. 
+    GRDC (2020): GRDC Major River Basins. Global Runoff Data Centre. 2nd, rev. ed.
     Koblenz: Federal Institute of Hydrology (BfG).
     """
-    
+
     url = "https://datacatalogfiles.worldbank.org/ddh-published/0041426/DR0051689/major_basins_of_the_world_0_0_0.zip"
-    
+
     # Convert bbox to GeoDataFrame if provided
-    bbox_gdf = convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
-    
+    bbox_gdf = (
+        convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    )
+
     # Load the data
     basins_gdf = gpd.read_file("zip+" + url)
-    
+
     # Clip to bbox if provided
     if bbox_gdf is not None:
         basins_gdf = basins_gdf.clip(bbox_gdf)
@@ -255,19 +272,25 @@ def get_grdc_major_river_basins_of_the_world(
         _logger.info("No spatial subsetting because bbox_input was not provided.")
 
     # Add citation to attributes
-    basins_gdf.attrs["data_citation"] = "GRDC (2020): GRDC Major River Basins. Global Runoff Data Centre. 2nd, rev. ed. Koblenz: Federal Institute of Hydrology (BfG)."
-    
+    basins_gdf.attrs["data_citation"] = (
+        "GRDC (2020): GRDC Major River Basins. Global Runoff Data Centre. 2nd, rev. ed. Koblenz: Federal Institute of Hydrology (BfG)."
+    )
+
     return basins_gdf
 
+
 def get_grdc_wmo_basins(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Retrieves WMO Basins and Sub-Basins dataset.
 
-    This function downloads and loads the Global Runoff Data Centre's (GRDC) WMO Basins 
+    This function downloads and loads the Global Runoff Data Centre's (GRDC) WMO Basins
     and Sub-Basins dataset. It contains 515 WMO Basins representing hydrographic regions
-    including river/lake basins with both exorheic drainage (flowing to oceans) and 
+    including river/lake basins with both exorheic drainage (flowing to oceans) and
     endorheic drainage (inland sinks/lakes).
 
     Parameters
@@ -295,7 +318,7 @@ def get_grdc_wmo_basins(
 
     Notes
     -----
-    This dataset incorporates data from the HydroSHEDS database which is © World Wildlife Fund, Inc. 
+    This dataset incorporates data from the HydroSHEDS database which is © World Wildlife Fund, Inc.
     (2006-2013) and has been used under license.
 
     WMO basins and sub-basins are attributed with:
@@ -311,17 +334,19 @@ def get_grdc_wmo_basins(
     - SUMSUBAREA: approximate of drainage area (in square km)
 
     Data citation:
-    GRDC (2020): WMO Basins and Sub-Basins / Global Runoff Data Centre, GRDC. 3rd, rev. ext. ed. 
+    GRDC (2020): WMO Basins and Sub-Basins / Global Runoff Data Centre, GRDC. 3rd, rev. ext. ed.
     Koblenz, Germany: Federal Institute of Hydrology (BfG).
     """
-    
+
     url = "https://grdc.bafg.de/downloads/wmobb_json.zip/wmobb_basins.json"
-    
+
     # Convert bbox to GeoDataFrame if provided
-    bbox_gdf = convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
-    
+    bbox_gdf = (
+        convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    )
+
     basins_gdf = gpd.read_file("zip+" + url)
-    
+
     # Clip to bbox if provided
     if bbox_gdf is not None:
         basins_gdf = basins_gdf.clip(bbox_gdf)
@@ -329,12 +354,18 @@ def get_grdc_wmo_basins(
         _logger.info("No spatial subsetting because bbox_input was not provided.")
 
     # Add citation to attributes
-    basins_gdf.attrs["data_citation"] = "GRDC (2020): WMO Basins and Sub-Basins / Global Runoff Data Centre, GRDC. 3rd, rev. ext. ed. Koblenz, Germany: Federal Institute of Hydrology (BfG)."
-    
+    basins_gdf.attrs["data_citation"] = (
+        "GRDC (2020): WMO Basins and Sub-Basins / Global Runoff Data Centre, GRDC. 3rd, rev. ext. ed. Koblenz, Germany: Federal Institute of Hydrology (BfG)."
+    )
+
     return basins_gdf
 
+
 def get_era5(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
     version: str = "ERA5",
     cadence: str = "HOURLY",
     source: str = "auto",  # "auto", "GEE", or "GCS"
@@ -345,13 +376,13 @@ def get_era5(
 ) -> xr.Dataset:
     """
     Retrieves ERA5 reanalysis data using optimal source selection.
-    
-    By default, this function uses Google Earth Engine for most requests, but automatically 
+
+    By default, this function uses Google Earth Engine for most requests, but automatically
     switches to the high-resolution ARCO-ERA5 Zarr dataset from Google Cloud Storage for
-    hourly ERA5 data due to its superior performance and coverage for that specific 
+    hourly ERA5 data due to its superior performance and coverage for that specific
     combination. Please note, these datasets may be different from the original ERA5 data
     hosted on the Copernicus Climate Data Store (CDS).
-    
+
     Parameters
     ----------
     bbox_input : geopandas.GeoDataFrame or tuple or shapely.Geometry, optional
@@ -361,7 +392,7 @@ def get_era5(
     cadence : str, optional
         Temporal resolution. Options are 'HOURLY', 'DAILY', or 'MONTHLY'. Default is 'HOURLY'.
     source : str, optional
-        Data source to use: "auto" (smart selection), "GEE" (Google Earth Engine), or 
+        Data source to use: "auto" (smart selection), "GEE" (Google Earth Engine), or
         "GCS" (Google Cloud Storage). Default is "auto", which uses GCS for ERA5 hourly data
         and GEE for everything else.
     start_date : str, optional
@@ -372,40 +403,40 @@ def get_era5(
         Variable(s) to select. If None, returns all variables. Only applicable for GEE source.
     initialize_ee : bool, optional
         Whether to initialize Earth Engine. Default is True. Only applicable for GEE source.
-        
+
     Returns
     -------
     xarray.Dataset
         An xarray Dataset containing ERA5 reanalysis data for the specified region.
-        
+
     Examples
     --------
     Get hourly ERA5 data (automatically uses ARCO-ERA5 from GCS):
-    
+
     >>> bbox = (-121.94, 46.72, -121.54, 46.99)
     >>> era5_ds = get_era5(bbox_input=bbox)  # Uses GCS for hourly ERA5
     >>> era5_ds["2m_temperature"].sel(time="2020-05-26").mean(dim="time").plot()
-    
+
     Get monthly ERA5 data (uses Google Earth Engine):
-    
+
     >>> era5_gee = get_era5(
     ...     bbox_input=bbox,
-    ...     cadence="MONTHLY", 
+    ...     cadence="MONTHLY",
     ...     start_date="2020-01-01",
     ...     end_date="2020-12-31",
     ...     variables=["temperature_2m"]
     ... )  # Uses GEE for monthly data
     >>> era5_gee["temperature_2m"].plot()
-    
+
     Force using GEE for hourly ERA5 data:
-    
+
     >>> era5_hourly_gee = get_era5(
     ...     bbox_input=bbox,
     ...     source="GEE",
     ...     start_date="2020-01-01",
     ...     end_date="2020-01-02"
     ... )  # Explicitly uses GEE for hourly data
-    
+
     Notes
     -----
     When *source* is ``"GEE"`` or ``"auto"`` selects GEE (all combinations except hourly ERA5),
@@ -420,56 +451,63 @@ def get_era5(
     - You can override the automatic source selection by explicitly setting the source parameter
     - Please note, these data are not the original ERA5 data but have been processed and optimized for cloud access. Each dataset will also have an assosciated latency different from the original dataset. The most up-to-date information can be found at: https://cds.climate.copernicus.eu/datasets
 
-    
+
     Data citations:
     - GEE+GCS: Hersbach, H., Bell, B., Berrisford, P., et al. (2020). The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society, 146(730), 1999-2049.
     - GCS: Carver, Robert W, and Merose, Alex. (2023): ARCO-ERA5: An Analysis-Ready Cloud-Optimized Reanalysis Dataset. 22nd Conf. on AI for Env. Science, Denver, CO, Amer. Meteo. Soc, 4A.1, https://ams.confex.com/ams/103ANNUAL/meetingapp.cgi/Paper/415842
     """
     # Determine the appropriate source based on parameters
     effective_source = source.upper()
-    
+
     if effective_source == "AUTO":
         if version == "ERA5" and cadence == "HOURLY":
             effective_source = "GCS"  # Use ARCO dataset for hourly ERA5
         else:
             effective_source = "GEE"  # Default to GEE for all other combinations
-    
+
     # Convert bbox to GeoDataFrame format for consistent handling
-    bbox_gdf = convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
-    
+    bbox_gdf = (
+        convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    )
+
     # Option 1: Google Cloud Storage (GCS) - ARCO-ERA5 Zarr dataset
     if effective_source == "GCS":
         # Verify we're using ERA5 hourly (the only supported option for GCS)
         if version != "ERA5" or cadence != "HOURLY":
-            raise ValueError(f"GCS source only supports ERA5 hourly data, not {version} {cadence}")
-            
+            raise ValueError(
+                f"GCS source only supports ERA5 hourly data, not {version} {cadence}"
+            )
+
         era5_ds = xr.open_zarr(
-            'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3',
+            "gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3",
             chunks=None,
-            storage_options=dict(token='anon'),
+            storage_options=dict(token="anon"),
         )
-        
+
         # Apply time filtering if specified
         if start_date is not None and end_date is not None:
             era5_ds = era5_ds.sel(time=slice(start_date, end_date))
         else:
-            era5_ds = era5_ds.sel(time=slice(era5_ds.attrs['valid_time_start'], 
-                                            era5_ds.attrs['valid_time_stop']))
-            
+            era5_ds = era5_ds.sel(
+                time=slice(
+                    era5_ds.attrs["valid_time_start"], era5_ds.attrs["valid_time_stop"]
+                )
+            )
+
         # Set CRS and normalize longitude coordinates
         era5_ds.rio.write_crs("EPSG:4326", inplace=True)
         era5_ds = era5_ds.assign_coords(
             longitude=(((era5_ds.longitude + 180) % 360) - 180)
-        ).sortby('longitude')
-        
+        ).sortby("longitude")
+
         # Add coordinate attributes
         era5_ds["longitude"].attrs["long_name"] = "longitude"
         era5_ds["longitude"].attrs["units"] = "degrees_east"
-        
+
         # Apply spatial subsetting if specified
         if bbox_gdf is not None:
             era5_ds = era5_ds.rio.clip_box(*bbox_gdf.total_bounds, crs=bbox_gdf.crs)
-            
+
         # Add metadata
         era5_ds.attrs["data_citation"] = (
             "Carver, Robert W, and Merose, Alex. (2023): ARCO-ERA5: An Analysis-Ready "
@@ -480,22 +518,29 @@ def get_era5(
         era5_ds.attrs["source"] = "Google Cloud Storage (ARCO-ERA5)"
         era5_ds.attrs["version"] = version
         era5_ds.attrs["cadence"] = cadence
-        
+
         return era5_ds
-        
+
     # Option 2: Google Earth Engine (GEE)
     elif effective_source == "GEE":
-        from easysnowdata.utils import CredentialError, _has_earthengine_credentials, _EE_SETUP_MSG  # noqa: PLC0415
+        from easysnowdata.utils import (
+            CredentialError,
+            _has_earthengine_credentials,
+            _EE_SETUP_MSG,
+        )  # noqa: PLC0415
+
         if not _has_earthengine_credentials():
             raise CredentialError(
                 f"`get_era5` with source='GEE' requires Google Earth Engine.\n\n{_EE_SETUP_MSG}"
             )
         # Initialize Earth Engine if requested
         if initialize_ee:
-            ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
+            ee.Initialize(opt_url="https://earthengine-highvolume.googleapis.com")
         else:
-            _logger.info("Earth Engine initialization skipped. Please ensure EE is initialized.")
-        
+            _logger.info(
+                "Earth Engine initialization skipped. Please ensure EE is initialized."
+            )
+
         # Collection name mapping
         collection_mapping = {
             ("ERA5_LAND", "HOURLY"): "ECMWF/ERA5_LAND/HOURLY",
@@ -503,71 +548,80 @@ def get_era5(
             ("ERA5_LAND", "MONTHLY"): "ECMWF/ERA5_LAND/MONTHLY_AGGR",
             ("ERA5", "HOURLY"): "ECMWF/ERA5/HOURLY",
             ("ERA5", "DAILY"): "ECMWF/ERA5/DAILY",
-            ("ERA5", "MONTHLY"): "ECMWF/ERA5/MONTHLY"
+            ("ERA5", "MONTHLY"): "ECMWF/ERA5/MONTHLY",
         }
-        
+
         # Get collection name
         collection_key = (version, cadence)
         if collection_key not in collection_mapping:
-            raise ValueError(f"Invalid combination of version '{version}' and cadence '{cadence}'")
-        
+            raise ValueError(
+                f"Invalid combination of version '{version}' and cadence '{cadence}'"
+            )
+
         collection_name = collection_mapping[collection_key]
-        
+
         # Initialize image collection
         image_collection = ee.ImageCollection(collection_name)
-        
+
         # Apply date filtering if specified
         if start_date is not None and end_date is not None:
             end_date = end_date + "T23:59:59"  # Include full end date
             image_collection = image_collection.filterDate(start_date, end_date)
-        
+
         # Apply variable selection if specified
         if variables is not None:
             if isinstance(variables, str):
                 variables = [variables]
             image_collection = image_collection.select(variables)
-        
+
         # Get projection from first image
         image = image_collection.first()
         projection = image.select(0).projection()
-        
+
         # Prepare geometry for GEE
         geometry = None
         if bbox_gdf is not None:
             geometry = tuple(bbox_gdf.total_bounds)
-        
+
         # Load dataset
         ds = xr.open_dataset(
             image_collection,
-            engine='ee',
+            engine="ee",
             geometry=geometry,
             projection=projection,
-            chunks=None
+            chunks=None,
         )
-        
+
         # Clean up dimensions and coordinate names
-        ds = (ds
-              .transpose('time', 'lat', 'lon')
-              .rename({'lat': 'latitude', 'lon': 'longitude'})
-              .rio.set_spatial_dims(x_dim='longitude', y_dim='latitude'))
-        
+        ds = (
+            ds.transpose("time", "lat", "lon")
+            .rename({"lat": "latitude", "lon": "longitude"})
+            .rio.set_spatial_dims(x_dim="longitude", y_dim="latitude")
+        )
+
         # Add metadata
-        ds.attrs['data_citation'] = (
+        ds.attrs["data_citation"] = (
             "Hersbach, H., Bell, B., Berrisford, P., et al. (2020). The ERA5 global reanalysis. "
             "Quarterly Journal of the Royal Meteorological Society, 146(730), 1999-2049."
         )
-        ds.attrs['version'] = version
-        ds.attrs['cadence'] = cadence
+        ds.attrs["version"] = version
+        ds.attrs["cadence"] = cadence
         ds.attrs["source"] = "Google Earth Engine"
-        
+
         return ds
-        
+
     else:
-        raise ValueError("Source must be 'auto', 'GEE' (Google Earth Engine), or 'GCS' (Google Cloud Storage)")
+        raise ValueError(
+            "Source must be 'auto', 'GEE' (Google Earth Engine), or 'GCS' (Google Cloud Storage)"
+        )
+
 
 @requires_earthengine
 def get_snodas(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
     start_date: str = "2003-10-01",
     end_date: str = None,
     variables: str | list | None = None,
@@ -576,14 +630,14 @@ def get_snodas(
     """
     Retrieves SNODAS (Snow Data Assimilation System) data for a given bounding box and time range.
 
-    The Snow Data Assimilation System (SNODAS) is a modeling and data assimilation system 
-    developed by NOHRSC that provides accurate estimations of snow cover and associated 
+    The Snow Data Assimilation System (SNODAS) is a modeling and data assimilation system
+    developed by NOHRSC that provides accurate estimations of snow cover and associated
     parameters at 1 km spatial resolution and daily temporal resolution.
 
     Parameters
     ----------
     bbox_input : geopandas.GeoDataFrame or tuple or Shapely Geometry, optional
-        GeoDataFrame containing the bounding box, or a tuple of (xmin, ymin, xmax, ymax), 
+        GeoDataFrame containing the bounding box, or a tuple of (xmin, ymin, xmax, ymax),
         or a Shapely geometry. If None, returns data for the entire dataset extent.
     start_date : str, optional
         The start date for the data in the format 'YYYY-MM-DD'. Default is '2003-10-01'.
@@ -606,17 +660,17 @@ def get_snodas(
 
     >>> import geopandas as gpd
     >>> import easysnowdata
-    >>> 
+    >>>
     >>> # Define a bounding box for an area of interest
     >>> bbox = (-121.94, 46.72, -121.54, 46.99)
-    >>> 
+    >>>
     >>> # Get SNODAS data for winter 2022
     >>> snodas_ds = easysnowdata.hydroclimatology.get_snodas(
     ...     bbox_input=bbox,
     ...     start_date="2022-01-01",
     ...     end_date="2022-03-31"
     ... )
-    >>> 
+    >>>
     >>> # Plot snow water equivalent
     >>> snodas_ds['SWE'].max(dim='time').plot(cmap='Blues')
 
@@ -640,30 +694,36 @@ def get_snodas(
     - Spatial resolution is 1 km (1/120-degree)
 
     Data citations:
-    Barrett, Andrew. 2003. National Operational Hydrologic Remote Sensing Center Snow Data 
-    Assimilation System (SNODAS) Products at NSIDC. NSIDC Special Report 11. Boulder, CO USA: 
+    Barrett, Andrew. 2003. National Operational Hydrologic Remote Sensing Center Snow Data
+    Assimilation System (SNODAS) Products at NSIDC. NSIDC Special Report 11. Boulder, CO USA:
     National Snow and Ice Data Center. 19 pp.
 
-    Barrett, A. P., R. L. Armstrong, and J. L. Smith. 2001. The Snow Data Assimilation System 
+    Barrett, A. P., R. L. Armstrong, and J. L. Smith. 2001. The Snow Data Assimilation System
     (SNODAS): An overview. Journal of Hydrometeorology 2(3):288-306.
     """
     import datetime
-    
+
     # Initialize Earth Engine if requested
     if initialize_ee:
-        ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
+        ee.Initialize(opt_url="https://earthengine-highvolume.googleapis.com")
     else:
-        _logger.info("Earth Engine initialization skipped. Please ensure EE is initialized.")
+        _logger.info(
+            "Earth Engine initialization skipped. Please ensure EE is initialized."
+        )
 
     # Set default end date to today if not provided
     if end_date is None:
-        end_date = datetime.datetime.now().strftime('%Y-%m-%d')
+        end_date = datetime.datetime.now().strftime("%Y-%m-%d")
 
     # Convert bbox to GeoDataFrame if provided
-    bbox_gdf = convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    bbox_gdf = (
+        convert_bbox_to_geodataframe(bbox_input) if bbox_input is not None else None
+    )
 
     # Initialize SNODAS image collection
-    collection_name = 'projects/earthengine-legacy/assets/projects/climate-engine/snodas/daily'
+    collection_name = (
+        "projects/earthengine-legacy/assets/projects/climate-engine/snodas/daily"
+    )
     image_collection = ee.ImageCollection(collection_name)
 
     # Apply date filtering
@@ -671,14 +731,16 @@ def get_snodas(
     image_collection = image_collection.filterDate(start_date, end_date_inclusive)
 
     # Apply variable selection if specified
-    available_variables = ['Snow_Depth', 'SWE']
+    available_variables = ["Snow_Depth", "SWE"]
     if variables is not None:
         if isinstance(variables, str):
             variables = [variables]
         # Validate variables
         invalid_vars = set(variables) - set(available_variables)
         if invalid_vars:
-            raise ValueError(f"Invalid variables: {invalid_vars}. Available variables: {available_variables}")
+            raise ValueError(
+                f"Invalid variables: {invalid_vars}. Available variables: {available_variables}"
+            )
         image_collection = image_collection.select(variables)
 
     # Get projection from first image
@@ -693,65 +755,77 @@ def get_snodas(
     # Load dataset using xee
     ds = xr.open_dataset(
         image_collection,
-        engine='ee',
+        engine="ee",
         geometry=geometry,
         projection=projection,
-        chunks=None
+        chunks=None,
     )
 
     # Clean up dimensions and coordinate names
-    ds = (ds
-          .transpose('time', 'lat', 'lon')
-          .rename({'lat': 'latitude', 'lon': 'longitude'})
-          .rio.set_spatial_dims(x_dim='longitude', y_dim='latitude'))
+    ds = (
+        ds.transpose("time", "lat", "lon")
+        .rename({"lat": "latitude", "lon": "longitude"})
+        .rio.set_spatial_dims(x_dim="longitude", y_dim="latitude")
+    )
 
     # Set coordinate reference system
     ds.rio.write_crs("EPSG:4326", inplace=True)
 
     # Add variable attributes
-    if 'Snow_Depth' in ds.data_vars:
-        ds['Snow_Depth'].attrs.update({
-            'long_name': 'Snow Depth',
-            'units': 'meters',
-            'description': 'Daily snow depth from SNODAS'
-        })
+    if "Snow_Depth" in ds.data_vars:
+        ds["Snow_Depth"].attrs.update(
+            {
+                "long_name": "Snow Depth",
+                "units": "meters",
+                "description": "Daily snow depth from SNODAS",
+            }
+        )
 
-    if 'SWE' in ds.data_vars:
-        ds['SWE'].attrs.update({
-            'long_name': 'Snow Water Equivalent',
-            'units': 'meters', 
-            'description': 'Daily snow water equivalent from SNODAS'
-        })
+    if "SWE" in ds.data_vars:
+        ds["SWE"].attrs.update(
+            {
+                "long_name": "Snow Water Equivalent",
+                "units": "meters",
+                "description": "Daily snow water equivalent from SNODAS",
+            }
+        )
 
     # Add dataset attributes
-    ds.attrs.update({
-        'title': 'Snow Data Assimilation System (SNODAS)',
-        'institution': 'National Operational Hydrologic Remote Sensing Center (NOHRSC)',
-        'source': 'Google Earth Engine (Climate Engine Org collection)',
-        'spatial_resolution': '1 km',
-        'temporal_resolution': 'Daily',
-        'coverage': 'Continental United States, Alaska, and Hawaii',
-        'data_citation': (
-            "Barrett, Andrew. 2003. National Operational Hydrologic Remote Sensing Center "
-            "Snow Data Assimilation System (SNODAS) Products at NSIDC. NSIDC Special Report 11. "
-            "Boulder, CO USA: National Snow and Ice Data Center. 19 pp.; "
-            "Barrett, A. P., R. L. Armstrong, and J. L. Smith. 2001. The Snow Data Assimilation "
-            "System (SNODAS): An overview. Journal of Hydrometeorology 2(3):288-306."
-        ),
-        'license': (
-            "NOAA data, information, and products, regardless of the method of delivery, "
-            "are not subject to copyright and carry no restrictions on their subsequent use by the public."
-        )
-    })
+    ds.attrs.update(
+        {
+            "title": "Snow Data Assimilation System (SNODAS)",
+            "institution": "National Operational Hydrologic Remote Sensing Center (NOHRSC)",
+            "source": "Google Earth Engine (Climate Engine Org collection)",
+            "spatial_resolution": "1 km",
+            "temporal_resolution": "Daily",
+            "coverage": "Continental United States, Alaska, and Hawaii",
+            "data_citation": (
+                "Barrett, Andrew. 2003. National Operational Hydrologic Remote Sensing Center "
+                "Snow Data Assimilation System (SNODAS) Products at NSIDC. NSIDC Special Report 11. "
+                "Boulder, CO USA: National Snow and Ice Data Center. 19 pp.; "
+                "Barrett, A. P., R. L. Armstrong, and J. L. Smith. 2001. The Snow Data Assimilation "
+                "System (SNODAS): An overview. Journal of Hydrometeorology 2(3):288-306."
+            ),
+            "license": (
+                "NOAA data, information, and products, regardless of the method of delivery, "
+                "are not subject to copyright and carry no restrictions on their subsequent use by the public."
+            ),
+        }
+    )
 
     return ds
 
+
 @requires_earthaccess
-def get_ucla_snow_reanalysis(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
-                             variable: str = 'SWE_Post',
-                             stats: str = 'mean',
-                             start_date: str = '1984-10-01',
-                             end_date: str = '2021-09-30',
+def get_ucla_snow_reanalysis(
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    variable: str = "SWE_Post",
+    stats: str = "mean",
+    start_date: str = "1984-10-01",
+    end_date: str = "2021-09-30",
 ) -> xr.DataArray:
     """
     Fetches the Margulis UCLA snow reanalysis product for a specified bounding box and time range.
@@ -784,9 +858,9 @@ def get_ucla_snow_reanalysis(bbox_input: gpd.GeoDataFrame | tuple | shapely.geom
     --------
     Get mean Snow Water Equivalent data for a specific region and time period...
 
-    >>> swe_reanalysis_da = easysnowdata.hydroclimatology.get_ucla_snow_reanalysis(bbox_input=(-121.94, 46.72, -121.54, 46.99), 
-    ...                                     variable='SWE_Post', 
-    ...                                     start_date='2000-01-01', 
+    >>> swe_reanalysis_da = easysnowdata.hydroclimatology.get_ucla_snow_reanalysis(bbox_input=(-121.94, 46.72, -121.54, 46.99),
+    ...                                     variable='SWE_Post',
+    ...                                     start_date='2000-01-01',
     ...                                     end_date='2000-12-31')
     >>> snow_reanalysis_da.isel(time=slice(0, 365, 30)).plot.imshow(col="time",col_wrap=5,cmap="Blues",vmin=0,vmax=3)
 
@@ -803,39 +877,54 @@ def get_ucla_snow_reanalysis(bbox_input: gpd.GeoDataFrame | tuple | shapely.geom
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
 
     search = earthaccess.search_data(
-                short_name="WUS_UCLA_SR",
-                cloud_hosted=True,
-                bounding_box=tuple(bbox_gdf.total_bounds),
-                temporal=(start_date, end_date),
-            )
-    
-    files = earthaccess.open(search) # cant disable progress bar yet https://github.com/nsidc/earthaccess/issues/612
+        short_name="WUS_UCLA_SR",
+        cloud_hosted=True,
+        bounding_box=tuple(bbox_gdf.total_bounds),
+        temporal=(start_date, end_date),
+    )
+
+    files = earthaccess.open(
+        search
+    )  # cant disable progress bar yet https://github.com/nsidc/earthaccess/issues/612
     snow_reanalysis_ds = xr.open_mfdataset(files).transpose()
 
     url = files[0].path
-    date_pattern = r'\d{4}\.\d{2}\.\d{2}'
+    date_pattern = r"\d{4}\.\d{2}\.\d{2}"
     WY_start_date = pd.to_datetime(re.search(date_pattern, url).group())
 
-    snow_reanalysis_ds.coords['time'] = ("Day", pd.date_range(WY_start_date, periods=snow_reanalysis_ds.sizes['Day']))
-    snow_reanalysis_ds = snow_reanalysis_ds.swap_dims({'Day':'time'})
+    snow_reanalysis_ds.coords["time"] = (
+        "Day",
+        pd.date_range(WY_start_date, periods=snow_reanalysis_ds.sizes["Day"]),
+    )
+    snow_reanalysis_ds = snow_reanalysis_ds.swap_dims({"Day": "time"})
 
     snow_reanalysis_ds = snow_reanalysis_ds.sel(time=slice(start_date, end_date))
 
-    stats_dictionary = {'mean':0, 'std':1, 'median':2, '25pct':2, '75pct':3}
+    stats_dictionary = {"mean": 0, "std": 1, "median": 2, "25pct": 2, "75pct": 3}
     stats_index = stats_dictionary[stats]
 
     snow_reanalysis_da = snow_reanalysis_ds[variable].sel(Stats=stats_index)
-    snow_reanalysis_da = snow_reanalysis_da.rio.set_spatial_dims(x_dim="Longitude", y_dim="Latitude")
+    snow_reanalysis_da = snow_reanalysis_da.rio.set_spatial_dims(
+        x_dim="Longitude", y_dim="Latitude"
+    )
     snow_reanalysis_da = snow_reanalysis_da.rio.write_crs(bbox_gdf.crs)
-    snow_reanalysis_da = snow_reanalysis_da.rio.clip_box(*bbox_gdf.total_bounds,crs=bbox_gdf.crs)
+    snow_reanalysis_da = snow_reanalysis_da.rio.clip_box(
+        *bbox_gdf.total_bounds, crs=bbox_gdf.crs
+    )
 
-    snow_reanalysis_da.attrs["data_citation"] = "Fang, Y., Liu, Y. & Margulis, S. A. (2022). Western United States UCLA Daily Snow Reanalysis. (WUS_UCLA_SR, Version 1). [Data Set]. Boulder, Colorado USA. NASA National Snow and Ice Data Center Distributed Active Archive Center. https://doi.org/10.5067/PP7T2GBI52I2"
-    
+    snow_reanalysis_da.attrs["data_citation"] = (
+        "Fang, Y., Liu, Y. & Margulis, S. A. (2022). Western United States UCLA Daily Snow Reanalysis. (WUS_UCLA_SR, Version 1). [Data Set]. Boulder, Colorado USA. NASA National Snow and Ice Data Center Distributed Active Archive Center. https://doi.org/10.5067/PP7T2GBI52I2"
+    )
+
     return snow_reanalysis_da
 
+
 def get_koppen_geiger_classes(
-        bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
-        resolution: str = "0.1 degree",
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    resolution: str = "0.1 degree",
 ) -> xr.DataArray:
     """
     Retrieves Köppen-Geiger climate classification data for a given bounding box and resolution.
@@ -878,45 +967,160 @@ def get_koppen_geiger_classes(
 
     def get_class_info():
         classes = {
-            1: {"name": "Af", "description": "Tropical, rainforest", "color": [0, 0, 255]},
-            2: {"name": "Am", "description": "Tropical, monsoon", "color": [0, 120, 255]},
-            3: {"name": "Aw", "description": "Tropical, savannah", "color": [70, 170, 250]},
-            4: {"name": "BWh", "description": "Arid, desert, hot", "color": [255, 0, 0]},
-            5: {"name": "BWk", "description": "Arid, desert, cold", "color": [255, 150, 150]},
-            6: {"name": "BSh", "description": "Arid, steppe, hot", "color": [245, 165, 0]},
-            7: {"name": "BSk", "description": "Arid, steppe, cold", "color": [255, 220, 100]},
-            8: {"name": "Csa", "description": "Temperate, dry summer, hot summer", "color": [255, 255, 0]},
-            9: {"name": "Csb", "description": "Temperate, dry summer, warm summer", "color": [200, 200, 0]},
-            10: {"name": "Csc", "description": "Temperate, dry summer, cold summer", "color": [150, 150, 0]},
-            11: {"name": "Cwa", "description": "Temperate, dry winter, hot summer", "color": [150, 255, 150]},
-            12: {"name": "Cwb", "description": "Temperate, dry winter, warm summer", "color": [100, 200, 100]},
-            13: {"name": "Cwc", "description": "Temperate, dry winter, cold summer", "color": [50, 150, 50]},
-            14: {"name": "Cfa", "description": "Temperate, no dry season, hot summer", "color": [200, 255, 80]},
-            15: {"name": "Cfb", "description": "Temperate, no dry season, warm summer", "color": [100, 255, 80]},
-            16: {"name": "Cfc", "description": "Temperate, no dry season, cold summer", "color": [50, 200, 0]},
-            17: {"name": "Dsa", "description": "Cold, dry summer, hot summer", "color": [255, 0, 255]},
-            18: {"name": "Dsb", "description": "Cold, dry summer, warm summer", "color": [200, 0, 200]},
-            19: {"name": "Dsc", "description": "Cold, dry summer, cold summer", "color": [150, 50, 150]},
-            20: {"name": "Dsd", "description": "Cold, dry summer, very cold winter", "color": [150, 100, 150]},
-            21: {"name": "Dwa", "description": "Cold, dry winter, hot summer", "color": [170, 175, 255]},
-            22: {"name": "Dwb", "description": "Cold, dry winter, warm summer", "color": [90, 120, 220]},
-            23: {"name": "Dwc", "description": "Cold, dry winter, cold summer", "color": [75, 80, 180]},
-            24: {"name": "Dwd", "description": "Cold, dry winter, very cold winter", "color": [50, 0, 135]},
-            25: {"name": "Dfa", "description": "Cold, no dry season, hot summer", "color": [0, 255, 255]},
-            26: {"name": "Dfb", "description": "Cold, no dry season, warm summer", "color": [55, 200, 255]},
-            27: {"name": "Dfc", "description": "Cold, no dry season, cold summer", "color": [0, 125, 125]},
-            28: {"name": "Dfd", "description": "Cold, no dry season, very cold winter", "color": [0, 70, 95]},
-            29: {"name": "ET", "description": "Polar, tundra", "color": [178, 178, 178]},
-            30: {"name": "EF", "description": "Polar, frost", "color": [102, 102, 102]}
+            1: {
+                "name": "Af",
+                "description": "Tropical, rainforest",
+                "color": [0, 0, 255],
+            },
+            2: {
+                "name": "Am",
+                "description": "Tropical, monsoon",
+                "color": [0, 120, 255],
+            },
+            3: {
+                "name": "Aw",
+                "description": "Tropical, savannah",
+                "color": [70, 170, 250],
+            },
+            4: {
+                "name": "BWh",
+                "description": "Arid, desert, hot",
+                "color": [255, 0, 0],
+            },
+            5: {
+                "name": "BWk",
+                "description": "Arid, desert, cold",
+                "color": [255, 150, 150],
+            },
+            6: {
+                "name": "BSh",
+                "description": "Arid, steppe, hot",
+                "color": [245, 165, 0],
+            },
+            7: {
+                "name": "BSk",
+                "description": "Arid, steppe, cold",
+                "color": [255, 220, 100],
+            },
+            8: {
+                "name": "Csa",
+                "description": "Temperate, dry summer, hot summer",
+                "color": [255, 255, 0],
+            },
+            9: {
+                "name": "Csb",
+                "description": "Temperate, dry summer, warm summer",
+                "color": [200, 200, 0],
+            },
+            10: {
+                "name": "Csc",
+                "description": "Temperate, dry summer, cold summer",
+                "color": [150, 150, 0],
+            },
+            11: {
+                "name": "Cwa",
+                "description": "Temperate, dry winter, hot summer",
+                "color": [150, 255, 150],
+            },
+            12: {
+                "name": "Cwb",
+                "description": "Temperate, dry winter, warm summer",
+                "color": [100, 200, 100],
+            },
+            13: {
+                "name": "Cwc",
+                "description": "Temperate, dry winter, cold summer",
+                "color": [50, 150, 50],
+            },
+            14: {
+                "name": "Cfa",
+                "description": "Temperate, no dry season, hot summer",
+                "color": [200, 255, 80],
+            },
+            15: {
+                "name": "Cfb",
+                "description": "Temperate, no dry season, warm summer",
+                "color": [100, 255, 80],
+            },
+            16: {
+                "name": "Cfc",
+                "description": "Temperate, no dry season, cold summer",
+                "color": [50, 200, 0],
+            },
+            17: {
+                "name": "Dsa",
+                "description": "Cold, dry summer, hot summer",
+                "color": [255, 0, 255],
+            },
+            18: {
+                "name": "Dsb",
+                "description": "Cold, dry summer, warm summer",
+                "color": [200, 0, 200],
+            },
+            19: {
+                "name": "Dsc",
+                "description": "Cold, dry summer, cold summer",
+                "color": [150, 50, 150],
+            },
+            20: {
+                "name": "Dsd",
+                "description": "Cold, dry summer, very cold winter",
+                "color": [150, 100, 150],
+            },
+            21: {
+                "name": "Dwa",
+                "description": "Cold, dry winter, hot summer",
+                "color": [170, 175, 255],
+            },
+            22: {
+                "name": "Dwb",
+                "description": "Cold, dry winter, warm summer",
+                "color": [90, 120, 220],
+            },
+            23: {
+                "name": "Dwc",
+                "description": "Cold, dry winter, cold summer",
+                "color": [75, 80, 180],
+            },
+            24: {
+                "name": "Dwd",
+                "description": "Cold, dry winter, very cold winter",
+                "color": [50, 0, 135],
+            },
+            25: {
+                "name": "Dfa",
+                "description": "Cold, no dry season, hot summer",
+                "color": [0, 255, 255],
+            },
+            26: {
+                "name": "Dfb",
+                "description": "Cold, no dry season, warm summer",
+                "color": [55, 200, 255],
+            },
+            27: {
+                "name": "Dfc",
+                "description": "Cold, no dry season, cold summer",
+                "color": [0, 125, 125],
+            },
+            28: {
+                "name": "Dfd",
+                "description": "Cold, no dry season, very cold winter",
+                "color": [0, 70, 95],
+            },
+            29: {
+                "name": "ET",
+                "description": "Polar, tundra",
+                "color": [178, 178, 178],
+            },
+            30: {"name": "EF", "description": "Polar, frost", "color": [102, 102, 102]},
         }
         return classes
 
     def get_class_cmap(classes):
-        colors = {k: [c/255 for c in v["color"]] for k, v in classes.items()}
+        colors = {k: [c / 255 for c in v["color"]] for k, v in classes.items()}
         return matplotlib.colors.ListedColormap([colors[i] for i in range(1, 31)])
-    
 
-    def plot_classes(self, ax=None, figsize=(8, 10), cbar_orientation='horizontal'):
+    def plot_classes(self, ax=None, figsize=(8, 10), cbar_orientation="horizontal"):
         if ax is None:
             f, ax = plt.subplots(figsize=figsize)
         else:
@@ -932,12 +1136,23 @@ def get_koppen_geiger_classes(
         cbar = f.colorbar(im, ax=ax, orientation=cbar_orientation, aspect=30, pad=0.08)
 
         cbar.set_ticks(np.arange(1, 31))
-        cbar.set_ticklabels([f"{v['name']}: {v['description']}" for k, v in self.attrs["class_info"].items()], fontsize=8)
+        cbar.set_ticklabels(
+            [
+                f"{v['name']}: {v['description']}"
+                for k, v in self.attrs["class_info"].items()
+            ],
+            fontsize=8,
+        )
 
-        if cbar_orientation == 'horizontal':
-            plt.setp(cbar.ax.get_xticklabels(), rotation=60, ha='right', rotation_mode='anchor')
+        if cbar_orientation == "horizontal":
+            plt.setp(
+                cbar.ax.get_xticklabels(),
+                rotation=60,
+                ha="right",
+                rotation_mode="anchor",
+            )
         else:
-            plt.setp(cbar.ax.get_yticklabels(), rotation=0, ha='right')
+            plt.setp(cbar.ax.get_yticklabels(), rotation=0, ha="right")
 
         ax.set_xlabel("Longitude")
         ax.set_ylabel("Latitude")
@@ -945,24 +1160,37 @@ def get_koppen_geiger_classes(
         f.tight_layout(pad=1.5, w_pad=1.5, h_pad=1.5)
 
         return f, ax
-    
+
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
 
-    resolution_dict = {"1 degree": "1p0", "0.5 degree": "0p5", "0.1 degree": "0p1", "1 km": "0p00833333"}
+    resolution_dict = {
+        "1 degree": "1p0",
+        "0.5 degree": "0p5",
+        "0.1 degree": "0p1",
+        "1 km": "0p00833333",
+    }
     resolution = resolution_dict[resolution]
 
-    koppen_geiger_da = rxr.open_rasterio(f"zip+https://figshare.com/ndownloader/files/45057352/koppen_geiger_tif.zip/1991_2020/koppen_geiger_{resolution}.tif").squeeze()
+    koppen_geiger_da = rxr.open_rasterio(
+        f"zip+https://figshare.com/ndownloader/files/45057352/koppen_geiger_tif.zip/1991_2020/koppen_geiger_{resolution}.tif"
+    ).squeeze()
 
-    koppen_geiger_da = koppen_geiger_da.rio.clip_box(*bbox_gdf.total_bounds,crs=bbox_gdf.crs)
-        
+    koppen_geiger_da = koppen_geiger_da.rio.clip_box(
+        *bbox_gdf.total_bounds, crs=bbox_gdf.crs
+    )
 
     koppen_geiger_da.attrs["class_info"] = get_class_info()
-    koppen_geiger_da.attrs["cmap"] = get_class_cmap(koppen_geiger_da.attrs["class_info"])
-    koppen_geiger_da.attrs["data_citation"] = "Beck, H.E., McVicar, T.R., Vergopolan, N. et al. High-resolution (1 km) Köppen-Geiger maps for 1901–2099 based on constrained CMIP6 projections. Sci Data 10, 724 (2023). https://doi.org/10.1038/s41597-023-02549-6"
+    koppen_geiger_da.attrs["cmap"] = get_class_cmap(
+        koppen_geiger_da.attrs["class_info"]
+    )
+    koppen_geiger_da.attrs["data_citation"] = (
+        "Beck, H.E., McVicar, T.R., Vergopolan, N. et al. High-resolution (1 km) Köppen-Geiger maps for 1901–2099 based on constrained CMIP6 projections. Sci Data 10, 724 (2023). https://doi.org/10.1038/s41597-023-02549-6"
+    )
 
-    koppen_geiger_da.attrs['example_plot'] = plot_classes
+    koppen_geiger_da.attrs["example_plot"] = plot_classes
 
     return koppen_geiger_da
+
 
 # huc map, from gee?
 

--- a/easysnowdata/remote_sensing.py
+++ b/easysnowdata/remote_sensing.py
@@ -97,7 +97,12 @@ def authenticate_all():
     _logger.info("Google Earth Engine: done. Call ee.Initialize() before use.")
 
 
-def get_forest_cover_fraction(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None, mask_nodata: bool = False,
+def get_forest_cover_fraction(
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    mask_nodata: bool = False,
 ) -> xr.DataArray:
     """
     Fetches ~100m forest cover fraction data for a given bounding box.
@@ -124,13 +129,13 @@ def get_forest_cover_fraction(bbox_input: gpd.GeoDataFrame | tuple | shapely.geo
     --------
     >>> import geopandas as gpd
     >>> from easysnowdata import remote_sensing
-    >>> 
+    >>>
     >>> # Define a bounding box for an area of interest
     >>> bbox = (-122.5, 47.0, -121.5, 48.0)
-    >>> 
+    >>>
     >>> # Fetch forest cover fraction data
     >>> forest_cover = remote_sensing.get_forest_cover_fraction(bbox)
-    >>> 
+    >>>
     >>> # Plot the data using the example plot function
     >>> f, ax = forest_cover.attrs['example_plot'](forest_cover)
 
@@ -147,17 +152,19 @@ def get_forest_cover_fraction(bbox_input: gpd.GeoDataFrame | tuple | shapely.geo
         else:
             f = ax.get_figure()
 
-        cmap = matplotlib.colormaps.get_cmap('Greens').copy()
-        cmap.set_over('white')  # Set values over 100 (i.e., 255) to white
+        cmap = matplotlib.colormaps.get_cmap("Greens").copy()
+        cmap.set_over("white")  # Set values over 100 (i.e., 255) to white
 
         im = self.plot.imshow(ax=ax, cmap=cmap, vmin=0, vmax=100, add_colorbar=False)
-        
-        cbar = plt.colorbar(im, ax=ax, extend='max')
-        cbar.set_label('Forest Cover Fraction (%)')
+
+        cbar = plt.colorbar(im, ax=ax, extend="max")
+        cbar.set_label("Forest Cover Fraction (%)")
 
         ax.set_xlabel("Longitude")
         ax.set_ylabel("Latitude")
-        ax.set_title("Copernicus Global Land Service Forest Cover Fraction\nLand Cover 100m: collection 3: epoch 2019")
+        ax.set_title(
+            "Copernicus Global Land Service Forest Cover Fraction\nLand Cover 100m: collection 3: epoch 2019"
+        )
         f.tight_layout(pad=1.5, w_pad=1.5, h_pad=1.5)
         f.dpi = 300
 
@@ -172,17 +179,22 @@ def get_forest_cover_fraction(bbox_input: gpd.GeoDataFrame | tuple | shapely.geo
         mask_and_scale=mask_nodata,
     )
 
-    fcf_da = fcf_da.rio.clip_box(*bbox_gdf.total_bounds,crs=bbox_gdf.crs).squeeze()
+    fcf_da = fcf_da.rio.clip_box(*bbox_gdf.total_bounds, crs=bbox_gdf.crs).squeeze()
 
-
-
-    fcf_da.attrs['example_plot'] = plot_forest_cover
-    fcf_da.attrs['data_citation'] = "Marcel Buchhorn, Bruno Smets, Luc Bertels, Bert De Roo, Myroslava Lesiv, Nandin-Erdene Tsendbazar, Martin Herold, & Steffen Fritz. (2020). Copernicus Global Land Service: Land Cover 100m: collection 3: epoch 2019: Globe (V3.0.1) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.3939050"
+    fcf_da.attrs["example_plot"] = plot_forest_cover
+    fcf_da.attrs["data_citation"] = (
+        "Marcel Buchhorn, Bruno Smets, Luc Bertels, Bert De Roo, Myroslava Lesiv, Nandin-Erdene Tsendbazar, Martin Herold, & Steffen Fritz. (2020). Copernicus Global Land Service: Land Cover 100m: collection 3: epoch 2019: Globe (V3.0.1) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.3939050"
+    )
 
     return fcf_da
 
 
-def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None, mask_nodata: bool = False,
+def get_seasonal_snow_classification(
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    mask_nodata: bool = False,
 ) -> xr.DataArray:
     """
     Fetches 10arcsec (~300m) Sturm & Liston 2021 seasonal snow classification data for a given bounding box.
@@ -209,13 +221,13 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
     --------
     >>> import geopandas as gpd
     >>> import easysnowdata
-    >>> 
+    >>>
     >>> # Define a bounding box for an area of interest
     >>> bbox = (-120.0, 40.0, -118.0, 42.0)
-    >>> 
+    >>>
     >>> # Fetch seasonal snow classification data
     >>> snow_classification_da = easysnowdata.remote_sensing.get_seasonal_snow_classification(bbox)
-    >>> 
+    >>>
     >>> # Plot the data using the example plot function
     >>> f,ax = snow_classification_da.attrs['example_plot'](snow_classification_da)
 
@@ -245,7 +257,7 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
             [classes[key]["color"] for key in classes.keys()]
         )
         return cmap
-    
+
     def plot_classes(self, ax=None, figsize=(8, 10), legend_kwargs=None):
         if ax is None:
             f, ax = plt.subplots(figsize=figsize)
@@ -254,20 +266,24 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
 
         class_values = sorted(list(self.attrs["class_info"].keys()))
         bounds = [
-            (class_values[i] + class_values[i + 1]) / 2 for i in range(len(class_values) - 1)
+            (class_values[i] + class_values[i + 1]) / 2
+            for i in range(len(class_values) - 1)
         ]
         bounds = [class_values[0] - 0.5] + bounds + [class_values[-1] + 0.5]
         norm = matplotlib.colors.BoundaryNorm(bounds, self.attrs["cmap"].N)
 
-        im = self.plot.imshow(ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False)
-        #ax.set_aspect("equal")
-
+        im = self.plot.imshow(
+            ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False
+        )
+        # ax.set_aspect("equal")
 
         legend_handles = []
         class_names = []
         for class_value, class_info in self.attrs["class_info"].items():
             legend_handles.append(
-                plt.Rectangle((0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black")
+                plt.Rectangle(
+                    (0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black"
+                )
             )
             class_names.append(class_info["name"])
 
@@ -291,7 +307,7 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
         f.dpi = 300
 
         return f, ax
-    
+
     # Convert the input to a GeoDataFrame if it's not already one
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
 
@@ -300,9 +316,9 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
         chunks=True,
         mask_and_scale=mask_nodata,
     )
-    snow_classification_da = (
-        snow_classification_da.rio.clip_box(*bbox_gdf.total_bounds,crs=bbox_gdf.crs).squeeze()
-    )
+    snow_classification_da = snow_classification_da.rio.clip_box(
+        *bbox_gdf.total_bounds, crs=bbox_gdf.crs
+    ).squeeze()
 
     if mask_nodata:
         snow_classification_da.rio.write_nodata(9, encoded=True, inplace=True)
@@ -310,16 +326,25 @@ def get_seasonal_snow_classification(bbox_input: gpd.GeoDataFrame | tuple | shap
         snow_classification_da.rio.set_nodata(9, inplace=True)
 
     snow_classification_da.attrs["class_info"] = get_class_info()
-    snow_classification_da.attrs["cmap"] = get_class_cmap(snow_classification_da.attrs["class_info"])
-    snow_classification_da.attrs['data_citation'] = "Liston, G. E. and M. Sturm. (2021). Global Seasonal-Snow Classification, Version 1 [Data Set]. Boulder, Colorado USA. National Snow and Ice Data Center. https://doi.org/10.5067/99FTCYYYLAQ0. Date Accessed 03-06-2024."
-    
-    snow_classification_da.attrs['example_plot'] = plot_classes
+    snow_classification_da.attrs["cmap"] = get_class_cmap(
+        snow_classification_da.attrs["class_info"]
+    )
+    snow_classification_da.attrs["data_citation"] = (
+        "Liston, G. E. and M. Sturm. (2021). Global Seasonal-Snow Classification, Version 1 [Data Set]. Boulder, Colorado USA. National Snow and Ice Data Center. https://doi.org/10.5067/99FTCYYYLAQ0. Date Accessed 03-06-2024."
+    )
+
+    snow_classification_da.attrs["example_plot"] = plot_classes
 
     return snow_classification_da
 
 
 def get_seasonal_mountain_snow_mask(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None, data_product: str = "mountain_snow", mask_nodata: bool = False,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    data_product: str = "mountain_snow",
+    mask_nodata: bool = False,
 ) -> xr.DataArray:
     """
     Fetches ~1km static global seasonal (mountain snow / snow) mask for a given bounding box.
@@ -348,13 +373,13 @@ def get_seasonal_mountain_snow_mask(
     --------
     >>> import geopandas as gpd
     >>> import easysnowdata
-    >>> 
+    >>>
     >>> # Define a bounding box for a mountainous area
     >>> bbox = (-106.0, 39.0, -105.0, 40.0)
-    >>> 
+    >>>
     >>> # Fetch mountain snow mask data
     >>> mountain_snow_da = easysnowdata.remote_sensing.get_seasonal_mountain_snow_mask(bbox)
-    >>> 
+    >>>
     >>> # Plot the data using the example plot function
     >>> f, ax = mountain_snow_da.attrs['example_plot'](mountain_snow_da)
 
@@ -383,7 +408,9 @@ def get_seasonal_mountain_snow_mask(
                 255: {"name": "Fill", "color": "#ffffff"},
             }
         else:
-            raise ValueError('Invalid data_product. Choose from "snow" or "mountain_snow".')
+            raise ValueError(
+                'Invalid data_product. Choose from "snow" or "mountain_snow".'
+            )
         return classes
 
     def get_class_cmap(classes):
@@ -391,7 +418,7 @@ def get_seasonal_mountain_snow_mask(
             [classes[key]["color"] for key in classes.keys()]
         )
         return cmap
-    
+
     def plot_classes(self, ax=None, figsize=(8, 10), legend_kwargs=None):
         if ax is None:
             f, ax = plt.subplots(figsize=figsize)
@@ -400,19 +427,24 @@ def get_seasonal_mountain_snow_mask(
 
         class_values = sorted(list(self.attrs["class_info"].keys()))
         bounds = [
-            (class_values[i] + class_values[i + 1]) / 2 for i in range(len(class_values) - 1)
+            (class_values[i] + class_values[i + 1]) / 2
+            for i in range(len(class_values) - 1)
         ]
         bounds = [class_values[0] - 0.5] + bounds + [class_values[-1] + 0.5]
         norm = matplotlib.colors.BoundaryNorm(bounds, self.attrs["cmap"].N)
 
-        im = self.plot.imshow(ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False)
-        #ax.set_aspect("equal")
+        im = self.plot.imshow(
+            ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False
+        )
+        # ax.set_aspect("equal")
 
         legend_handles = []
         class_names = []
         for class_value, class_info in self.attrs["class_info"].items():
             legend_handles.append(
-                plt.Rectangle((0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black")
+                plt.Rectangle(
+                    (0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black"
+                )
             )
             class_names.append(class_info["name"])
 
@@ -431,23 +463,29 @@ def get_seasonal_mountain_snow_mask(
 
         ax.set_xlabel("Longitude")
         ax.set_ylabel("Latitude")
-        ax.set_title(f"Global seasonal {'mountain ' if data_product == 'mountain_snow' else ''}snow mask\nfrom Wrzesien et al 2019")
+        ax.set_title(
+            f"Global seasonal {'mountain ' if data_product == 'mountain_snow' else ''}snow mask\nfrom Wrzesien et al 2019"
+        )
         f.tight_layout(pad=5.5, w_pad=5.5, h_pad=1.5)
         f.dpi = 300
 
         return f, ax
 
-    print(f'This function takes a moment, getting zipped file from zenodo...')
+    print(f"This function takes a moment, getting zipped file from zenodo...")
     # Convert the input to a GeoDataFrame if it's not already one
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
 
     url = f"zip+https://zenodo.org/records/2626737/files/MODIS_{'mtnsnow' if data_product == 'mountain_snow' else 'snow'}_classes.zip!/MODIS_{'mtnsnow' if data_product == 'mountain_snow' else 'snow'}_classes.tif"
 
-    mountain_snow_da = rxr.open_rasterio(
-        url,
-        chunks=True,
-        mask_and_scale=mask_nodata,
-    ).rio.clip_box(*bbox_gdf.total_bounds, crs=bbox_gdf.crs).squeeze()
+    mountain_snow_da = (
+        rxr.open_rasterio(
+            url,
+            chunks=True,
+            mask_and_scale=mask_nodata,
+        )
+        .rio.clip_box(*bbox_gdf.total_bounds, crs=bbox_gdf.crs)
+        .squeeze()
+    )
 
     # looks like the creators accidently set no data to 256 and 265 instead of 255, therefore unmasked the data is of type uint32 :(
     # attempt to fix this by setting all invalid values to 255, then converting types
@@ -455,23 +493,32 @@ def get_seasonal_mountain_snow_mask(
     mountain_snow_da = mountain_snow_da.where(~mask, 255)
 
     if mask_nodata:
-        mountain_snow_da = mountain_snow_da.astype("float32").rio.write_nodata(255, encoded=True)
+        mountain_snow_da = mountain_snow_da.astype("float32").rio.write_nodata(
+            255, encoded=True
+        )
     else:
         mountain_snow_da = mountain_snow_da.astype("uint8").rio.set_nodata(255)
 
-
     mountain_snow_da.attrs["class_info"] = get_class_info(data_product)
-    mountain_snow_da.attrs["cmap"] = get_class_cmap(mountain_snow_da.attrs["class_info"])
-    mountain_snow_da.attrs['data_citation'] = "Wrzesien, M., Pavelsky, T., Durand, M., Lundquist, J., & Dozier, J. (2019). Global Seasonal Mountain Snow Mask from MODIS MOD10A2 [Data set]. Zenodo. https://doi.org/10.5281/zenodo.2626737"
-    
-    mountain_snow_da.attrs['example_plot'] = plot_classes
+    mountain_snow_da.attrs["cmap"] = get_class_cmap(
+        mountain_snow_da.attrs["class_info"]
+    )
+    mountain_snow_da.attrs["data_citation"] = (
+        "Wrzesien, M., Pavelsky, T., Durand, M., Lundquist, J., & Dozier, J. (2019). Global Seasonal Mountain Snow Mask from MODIS MOD10A2 [Data set]. Zenodo. https://doi.org/10.5281/zenodo.2626737"
+    )
+
+    mountain_snow_da.attrs["example_plot"] = plot_classes
 
     return mountain_snow_da
 
 
 def get_esa_worldcover(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
-    version: str = "v200", mask_nodata: bool = False,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    version: str = "v200",
+    mask_nodata: bool = False,
 ) -> xr.DataArray:
     """
     Fetches 10m ESA WorldCover global land cover data (2020 v100 or 2021 v200) for a given bounding box.
@@ -500,13 +547,13 @@ def get_esa_worldcover(
     --------
     >>> import geopandas as gpd
     >>> import easysnowdata
-    >>> 
+    >>>
     >>> # Define a bounding box for Mount Rainier
     >>> bbox = (-121.94, 46.72, -121.54, 46.99)
-    >>> 
+    >>>
     >>> # Fetch WorldCover data for the area
     >>> worldcover_da = easysnowdata.remote_sensing.get_esa_worldcover(bbox)
-    >>> 
+    >>>
     >>> # Plot the data using the example plot function
     >>> f, ax = worldcover_da.attrs['example_plot'](worldcover_da)
 
@@ -539,7 +586,7 @@ def get_esa_worldcover(
             [classes[key]["color"] for key in classes.keys()]
         )
         return cmap
-    
+
     def plot_classes(self, ax=None, figsize=(8, 10), legend_kwargs=None):
         if ax is None:
             f, ax = plt.subplots(figsize=figsize)
@@ -548,19 +595,24 @@ def get_esa_worldcover(
 
         class_values = sorted(list(self.attrs["class_info"].keys()))
         bounds = [
-            (class_values[i] + class_values[i + 1]) / 2 for i in range(len(class_values) - 1)
+            (class_values[i] + class_values[i + 1]) / 2
+            for i in range(len(class_values) - 1)
         ]
         bounds = [class_values[0] - 0.5] + bounds + [class_values[-1] + 0.5]
         norm = matplotlib.colors.BoundaryNorm(bounds, self.attrs["cmap"].N)
 
-        im = self.plot.imshow(ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False)
-        #ax.set_aspect("equal")
+        im = self.plot.imshow(
+            ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False
+        )
+        # ax.set_aspect("equal")
 
         legend_handles = []
         class_names = []
         for class_value, class_info in self.attrs["class_info"].items():
             legend_handles.append(
-                plt.Rectangle((0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black")
+                plt.Rectangle(
+                    (0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black"
+                )
             )
             class_names.append(class_info["name"])
 
@@ -609,28 +661,35 @@ def get_esa_worldcover(
     )
 
     if mask_nodata:
-        worldcover_da = worldcover_da.where(worldcover_da>0)
+        worldcover_da = worldcover_da.where(worldcover_da > 0)
         worldcover_da.rio.write_nodata(0, encoded=True, inplace=True)
 
     worldcover_da.attrs["class_info"] = get_class_info()
     worldcover_da.attrs["cmap"] = get_class_cmap(worldcover_da.attrs["class_info"])
-    worldcover_da.attrs['data_citation'] = "Zanaga, D., Van De Kerchove, R., De Keersmaecker, W., Souverijns, N., Brockmann, C., Quast, R., Wevers, J., Grosu, A., Paccini, A., Vergnaud, S., Cartus, O., Santoro, M., Fritz, S., Georgieva, I., Lesiv, M., Carter, S., Herold, M., Li, Linlin, Tsendbazar, N.E., Ramoino, F., Arino, O. (2021). ESA WorldCover 10 m 2020 v100. doi:10.5281/zenodo.5571936."
-    
-    worldcover_da.attrs['example_plot'] = plot_classes
+    worldcover_da.attrs["data_citation"] = (
+        "Zanaga, D., Van De Kerchove, R., De Keersmaecker, W., Souverijns, N., Brockmann, C., Quast, R., Wevers, J., Grosu, A., Paccini, A., Vergnaud, S., Cartus, O., Santoro, M., Fritz, S., Georgieva, I., Lesiv, M., Carter, S., Herold, M., Li, Linlin, Tsendbazar, N.E., Ramoino, F., Arino, O. (2021). ESA WorldCover 10 m 2020 v100. doi:10.5281/zenodo.5571936."
+    )
+
+    worldcover_da.attrs["example_plot"] = plot_classes
 
     return worldcover_da
 
 
 @requires_earthengine
-def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
-             layer: str = 'landcover',
-             initialize_ee: bool = True) -> xr.DataArray:
+def get_nlcd_landcover(
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
+    layer: str = "landcover",
+    initialize_ee: bool = True,
+) -> xr.DataArray:
     """
     Fetches National Land Cover Database (NLCD) data for a given bounding box.
 
     Description:
-    The National Land Cover Database (NLCD) provides nationwide data on land cover and land cover change 
-    at a 30m resolution. The dataset includes various layers such as land cover classification, 
+    The National Land Cover Database (NLCD) provides nationwide data on land cover and land cover change
+    at a 30m resolution. The dataset includes various layers such as land cover classification,
     impervious surfaces, and urban intensity. Projection is an albers equal area conic projection.
 
     Parameters
@@ -660,13 +719,13 @@ def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.b
     --------
     >>> import geopandas as gpd
     >>> import easysnowdata
-    >>> 
+    >>>
     >>> # Define a bounding box for an area of interest
     >>> bbox = (-122.5, 47.0, -121.5, 48.0)
-    >>> 
+    >>>
     >>> # Fetch NLCD land cover data
     >>> nlcd_landcover_da = easysnowdata.remote_sensing.get_nlcd_landcover(bbox, layer='landcover')
-    >>> 
+    >>>
     >>> # Plot the data
     >>> nlcd_landcover_da.attrs['example_plot'](nlcd_landcover_da)
 
@@ -685,76 +744,80 @@ def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.b
     """
     # Initialize Earth Engine with high-volume endpoint
     if initialize_ee:
-        ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
+        ee.Initialize(opt_url="https://earthengine-highvolume.googleapis.com")
     else:
-        _logger.info("Earth Engine initialization skipped. Ensure EE is already initialized.")
+        _logger.info(
+            "Earth Engine initialization skipped. Ensure EE is already initialized."
+        )
 
     # Convert the input to a GeoDataFrame if it's not already one
     bbox_gdf = convert_bbox_to_geodataframe(bbox_input)
 
-    image_collection = ee.ImageCollection('USGS/NLCD_RELEASES/2021_REL/NLCD')
+    image_collection = ee.ImageCollection("USGS/NLCD_RELEASES/2021_REL/NLCD")
     image = image_collection.first()
-    
+
     projection = image.select(0).projection()
-    
-    ds = xr.open_dataset(
-        image_collection, 
-        engine='ee', 
-        geometry=tuple(bbox_gdf.total_bounds), 
-        projection=projection,
-        chunks={},
-    ).squeeze().transpose().rename({'X':'x','Y':'y'}).rio.set_spatial_dims(x_dim='x', y_dim='y').astype('uint8')
-    
+
+    ds = (
+        xr.open_dataset(
+            image_collection,
+            engine="ee",
+            geometry=tuple(bbox_gdf.total_bounds),
+            projection=projection,
+            chunks={},
+        )
+        .squeeze()
+        .transpose()
+        .rename({"X": "x", "Y": "y"})
+        .rio.set_spatial_dims(x_dim="x", y_dim="y")
+        .astype("uint8")
+    )
+
     nlcd_da = ds[layer]
 
     # would be nice for them to come in as ints
     # https://github.com/google/Xee/issues/86
     # https://github.com/google/Xee/issues/146
-    
-    
+
     def get_class_info():
-        info = image.getInfo()['properties']
-        
-        if layer == 'landcover':
+        info = image.getInfo()["properties"]
+
+        if layer == "landcover":
             return {
-                value: {
-                    "name": name.split(':')[0],
-                    "color": f"#{palette}"
-                } for value, name, palette in zip(
-                    info['landcover_class_values'],
-                    info['landcover_class_names'],
-                    info['landcover_class_palette']
+                value: {"name": name.split(":")[0], "color": f"#{palette}"}
+                for value, name, palette in zip(
+                    info["landcover_class_values"],
+                    info["landcover_class_names"],
+                    info["landcover_class_palette"],
                 )
             }
-        elif layer == 'impervious':
-            return None  
-        elif layer == 'impervious_descriptor':
+        elif layer == "impervious":
+            return None
+        elif layer == "impervious_descriptor":
             return {
-                value: {
-                    "name": name.split('.')[0],
-                    "color": f"#{palette}"
-                } for value, name, palette in zip(
-                    info['impervious_descriptor_class_values'],
-                    info['impervious_descriptor_class_names'],
-                    info['impervious_descriptor_class_palette']
+                value: {"name": name.split(".")[0], "color": f"#{palette}"}
+                for value, name, palette in zip(
+                    info["impervious_descriptor_class_values"],
+                    info["impervious_descriptor_class_names"],
+                    info["impervious_descriptor_class_palette"],
                 )
             }
-        elif layer.startswith('science_products'):
+        elif layer.startswith("science_products"):
             return {
-                value: {
-                    "name": name,
-                    "color": f"#{palette}"
-                } for value, name, palette in zip(
-                    info[f'{layer}_class_values'],
-                    info[f'{layer}_class_names'],
-                    info[f'{layer}_class_palette']
+                value: {"name": name, "color": f"#{palette}"}
+                for value, name, palette in zip(
+                    info[f"{layer}_class_values"],
+                    info[f"{layer}_class_names"],
+                    info[f"{layer}_class_palette"],
                 )
             }
 
     def get_class_cmap(classes):
-        if classes is None: 
+        if classes is None:
             return plt.cm.YlOrRd
-        return plt.cm.colors.ListedColormap([classes[key]["color"] for key in classes.keys()])
+        return plt.cm.colors.ListedColormap(
+            [classes[key]["color"] for key in classes.keys()]
+        )
 
     def plot_classes(self, ax=None, figsize=(8, 10), legend_kwargs=None):
         if ax is None:
@@ -762,19 +825,26 @@ def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.b
         else:
             f = ax.get_figure()
 
-        if self.name != 'impervious':
+        if self.name != "impervious":
             class_values = sorted(list(self.attrs["class_info"].keys()))
-            bounds = [(class_values[i] + class_values[i + 1]) / 2 for i in range(len(class_values) - 1)]
+            bounds = [
+                (class_values[i] + class_values[i + 1]) / 2
+                for i in range(len(class_values) - 1)
+            ]
             bounds = [class_values[0] - 0.5] + bounds + [class_values[-1] + 0.5]
             norm = matplotlib.colors.BoundaryNorm(bounds, self.attrs["cmap"].N)
 
-            im = self.plot.imshow(ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False)
+            im = self.plot.imshow(
+                ax=ax, cmap=self.attrs["cmap"], norm=norm, add_colorbar=False
+            )
 
             legend_handles = []
             class_names = []
             for class_value, class_info in self.attrs["class_info"].items():
                 legend_handles.append(
-                    plt.Rectangle((0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black")
+                    plt.Rectangle(
+                        (0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black"
+                    )
                 )
                 class_names.append(class_info["name"])
 
@@ -790,15 +860,15 @@ def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.b
             legend_kwargs = {**default_legend_kwargs, **legend_kwargs}
             ax.legend(legend_handles, class_names, **legend_kwargs)
 
-        else: 
+        else:
             im = self.plot.imshow(ax=ax, cmap=self.attrs["cmap"], add_colorbar=False)
-            f.colorbar(im, ax=ax, label='Percent impervious surface [%]')
+            f.colorbar(im, ax=ax, label="Percent impervious surface [%]")
 
         ax.set_xlabel("x")
         ax.set_ylabel("y")
-        #ax.axis('equal')
+        # ax.axis('equal')
         ax.set_title(f"NLCD {self.name.title()} (2021)")
-        #f.tight_layout(pad=0, w_pad=0, h_pad=0)
+        # f.tight_layout(pad=0, w_pad=0, h_pad=0)
         f.dpi = 300
 
         return f, ax
@@ -808,10 +878,12 @@ def get_nlcd_landcover(bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.b
     nlcd_da.attrs["cmap"] = get_class_cmap(class_info)
     nlcd_da.attrs["example_plot"] = plot_classes
 
-    nlcd_da.attrs['data_citation'] = "Dewitz, J., 2023, National Land Cover Database (NLCD) 2021 Products: U.S. Geological Survey data release, doi:10.5066/P9JZ7AO3"
-
+    nlcd_da.attrs["data_citation"] = (
+        "Dewitz, J., 2023, National Land Cover Database (NLCD) 2021 Products: U.S. Geological Survey data release, doi:10.5066/P9JZ7AO3"
+    )
 
     return nlcd_da
+
 
 class Sentinel2:
     """
@@ -900,7 +972,7 @@ class Sentinel2:
         start_date="2014-01-01",
         end_date=today,
         catalog_choice="planetarycomputer",
-        collection= "sentinel-2-l2a", # could also choose "sentinel-2-c1-l2a" once published to https://github.com/Element84/earth-search
+        collection="sentinel-2-l2a",  # could also choose "sentinel-2-c1-l2a" once published to https://github.com/Element84/earth-search
         bands=None,
         resolution=None,
         crs=None,
@@ -1093,10 +1165,12 @@ class Sentinel2:
                     self.harmonize_to_old = True
                 elif self.collection == "sentinel-2-l2a":
                     self.harmonize_to_old = False
-                    print(f"Since {self.collection} on {self.catalog_choice} is used, harmonization step is not needed.")
+                    print(
+                        f"Since {self.collection} on {self.catalog_choice} is used, harmonization step is not needed."
+                    )
                 else:
                     raise ValueError(f"Unknown collection: {self.collection}")
-                
+
         if self.harmonize_to_old:
             self.harmonize_to_old_inplace()
 
@@ -1105,21 +1179,22 @@ class Sentinel2:
 
         self.get_metadata()
 
-
-
         # Add the plot_scl method as an attribute to the SCL data variable
-        if 'scl' in self.data.data_vars:
-            self.data.scl.attrs['example_plot'] = self.plot_scl
-            self.data.scl.attrs['class_info'] = self.scl_class_info
-            self.data.scl.attrs['cmap'] = self.scl_cmap
+        if "scl" in self.data.data_vars:
+            self.data.scl.attrs["example_plot"] = self.plot_scl
+            self.data.scl.attrs["class_info"] = self.scl_class_info
+            self.data.scl.attrs["cmap"] = self.scl_cmap
 
     def plot_scl(self, scl_data, ax=None, figsize=None, col_wrap=5, legend_kwargs=None):
-        
+
         if figsize is None:
             figsize = (8, 10) if scl_data.time.size == 1 else (12, 7)
 
         class_values = sorted(list(self.scl_class_info.keys()))
-        bounds = [(class_values[i] + class_values[i + 1]) / 2 for i in range(len(class_values) - 1)]
+        bounds = [
+            (class_values[i] + class_values[i + 1]) / 2
+            for i in range(len(class_values) - 1)
+        ]
         bounds = [class_values[0] - 0.5] + bounds + [class_values[-1] + 0.5]
         norm = matplotlib.colors.BoundaryNorm(bounds, self.scl_cmap.N)
 
@@ -1130,37 +1205,53 @@ class Sentinel2:
             else:
                 f = ax.get_figure()
 
-            im = scl_data.plot.imshow(ax=ax, cmap=self.scl_cmap, norm=norm, add_colorbar=False)
+            im = scl_data.plot.imshow(
+                ax=ax, cmap=self.scl_cmap, norm=norm, add_colorbar=False
+            )
             ax.set_aspect("equal")
 
-            local_time = pd.to_datetime(scl_data.time.values).tz_localize('UTC').tz_convert('America/Los_Angeles')
-            ax.set_title(f"Sentinel-2 Scene Classification Layer (SCL)\n{local_time.strftime('%B %d, %Y')}\n{local_time.strftime('%I:%M%p')}")
+            local_time = (
+                pd.to_datetime(scl_data.time.values)
+                .tz_localize("UTC")
+                .tz_convert("America/Los_Angeles")
+            )
+            ax.set_title(
+                f"Sentinel-2 Scene Classification Layer (SCL)\n{local_time.strftime('%B %d, %Y')}\n{local_time.strftime('%I:%M%p')}"
+            )
 
         else:
             # Multiple images plot
             f = scl_data.plot.imshow(
-                col='time',
+                col="time",
                 col_wrap=col_wrap,
                 cmap=self.scl_cmap,
                 norm=matplotlib.colors.BoundaryNorm(bounds, self.scl_cmap.N),
                 add_colorbar=False,
-                #figsize=figsize
+                # figsize=figsize
             )
 
             for ax, time in zip(f.axs.flat, scl_data.time.values):
-                local_time = pd.to_datetime(time).tz_localize('UTC').tz_convert('America/Los_Angeles')
-                ax.set_title(f'{local_time.strftime("%B %d, %Y")}\n{local_time.strftime("%I:%M%p")}')
-                ax.axis('off')
-                ax.set_aspect('equal')
+                local_time = (
+                    pd.to_datetime(time)
+                    .tz_localize("UTC")
+                    .tz_convert("America/Los_Angeles")
+                )
+                ax.set_title(
+                    f"{local_time.strftime('%B %d, %Y')}\n{local_time.strftime('%I:%M%p')}"
+                )
+                ax.axis("off")
+                ax.set_aspect("equal")
 
-            f.fig.suptitle('Sentinel-2 SCL time series', fontsize=16, y=1.02)
+            f.fig.suptitle("Sentinel-2 SCL time series", fontsize=16, y=1.02)
 
         # Add legend
         legend_handles = []
         class_names = []
         for class_value, class_info in self.scl_class_info.items():
             legend_handles.append(
-                plt.Rectangle((0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black")
+                plt.Rectangle(
+                    (0, 0), 1, 1, facecolor=class_info["color"], edgecolor="black"
+                )
             )
             class_names.append(class_info["name"])
 
@@ -1290,13 +1381,17 @@ class Sentinel2:
             nodata_value = None
             nodata_value = self.data[band].attrs.get("nodata")
             if nodata_value is not None:
-                #print(f"Removing nodata {nodata_value} values for band {band}...")
+                # print(f"Removing nodata {nodata_value} values for band {band}...")
                 self.data[band] = self.data[band].where(self.data[band] != nodata_value)
                 data_removed = True
         if data_removed:
-            print(f"Nodata values removed from the data. In doing so, all bands converted to float32. To turn this behavior off, set remove_nodata=False.")
+            print(
+                f"Nodata values removed from the data. In doing so, all bands converted to float32. To turn this behavior off, set remove_nodata=False."
+            )
         else:
-            print(f"Tried to remove nodata values and set them to nans, but no nodata values found in the data.")
+            print(
+                f"Tried to remove nodata values and set them to nans, but no nodata values found in the data."
+            )
 
     def mask_data(
         self,
@@ -1416,16 +1511,29 @@ class Sentinel2:
             scale_factor = self.data[band].attrs.get("scale")
 
             if scale_factor is None:
-                scale_factor = next((info['scale'] for name, info in self.band_info.items() if info['name'] == band), None)
+                scale_factor = next(
+                    (
+                        info["scale"]
+                        for name, info in self.band_info.items()
+                        if info["name"] == band
+                    ),
+                    None,
+                )
 
-            scale_factor = int(scale_factor) if scale_factor == '1' else float(scale_factor)
+            scale_factor = (
+                int(scale_factor) if scale_factor == "1" else float(scale_factor)
+            )
             self.data[band] = self.data[band] * scale_factor
 
         print(
             f"Data scaled to float reflectance. To turn this behavior off, set scale_data=False."
         )
 
-    def get_rgb(self, percentile_kwargs={'lower': 2, 'upper': 98}, clahe_kwargs={'clip_limit': 0.03, 'nbins': 256, 'kernel_size': None}):
+    def get_rgb(
+        self,
+        percentile_kwargs={"lower": 2, "upper": 98},
+        clahe_kwargs={"clip_limit": 0.03, "nbins": 256, "kernel_size": None},
+    ):
         """
         Retrieve RGB data with optional percentile-based contrast stretching and CLAHE enhancement.
 
@@ -1456,16 +1564,22 @@ class Sentinel2:
         - .rgb_clahe: CLAHE-enhanced RGB data
         """
 
-        rgba_da = self.data.odc.to_rgba(bands=('red','green','blue'),vmin=0, vmax=1.7)
+        rgba_da = self.data.odc.to_rgba(
+            bands=("red", "green", "blue"), vmin=0, vmax=1.7
+        )
         self.rgba = rgba_da
 
-        rgb_da = rgba_da.isel(band=slice(0, 3))  #.where(self.data.scl>=0, other=255) if we want to make no data white
+        rgb_da = rgba_da.isel(
+            band=slice(0, 3)
+        )  # .where(self.data.scl>=0, other=255) if we want to make no data white
         self.rgb = rgb_da
 
         self.rgb_percentile = self.get_rgb_percentile(**percentile_kwargs)
         self.rgb_clahe = self.get_rgb_clahe(**clahe_kwargs)
 
-        print(f"RGB data retrieved.\nAccess with the following attributes:\n.rgb for raw RGB,\n.rgba for RGBA,\n.rgb_percentile for percentile RGB,\n.rgb_clahe for CLAHE RGB.\nYou can pass in percentile_kwargs and clahe_kwargs to adjust RGB calculations, check documentation for options.")
+        print(
+            f"RGB data retrieved.\nAccess with the following attributes:\n.rgb for raw RGB,\n.rgba for RGBA,\n.rgb_percentile for percentile RGB,\n.rgb_clahe for CLAHE RGB.\nYou can pass in percentile_kwargs and clahe_kwargs to adjust RGB calculations, check documentation for options."
+        )
 
     def get_rgb_percentile(self, **percentile_kwargs):
         """
@@ -1489,21 +1603,23 @@ class Sentinel2:
         -----
         The function clips values to the range [0, 1] and masks areas where SCL < 0.
         """
-        lower_percentile = percentile_kwargs.get('lower', 2)
-        upper_percentile = percentile_kwargs.get('upper', 98)
+        lower_percentile = percentile_kwargs.get("lower", 2)
+        upper_percentile = percentile_kwargs.get("upper", 98)
 
         def stretch_percentile(da):
-            p_low, p_high = np.nanpercentile(da.values, [lower_percentile, upper_percentile])
+            p_low, p_high = np.nanpercentile(
+                da.values, [lower_percentile, upper_percentile]
+            )
             return (da - p_low) / (p_high - p_low)
 
         rgb_da = self.rgb
-        
+
         template = xr.zeros_like(rgb_da)
         rgb_percentile_da = xr.map_blocks(stretch_percentile, rgb_da, template=template)
-        rgb_percentile_da = rgb_percentile_da.clip(0, 1).where(self.data.scl>=0)
+        rgb_percentile_da = rgb_percentile_da.clip(0, 1).where(self.data.scl >= 0)
 
         return rgb_percentile_da
-    
+
     def get_rgb_clahe(self, **kwargs):
         """
         Apply Contrast Limited Adaptive Histogram Equalization (CLAHE) to RGB bands.
@@ -1533,17 +1649,19 @@ class Sentinel2:
         def equalize_adapthist_da(da, **kwargs):
             # Apply the CLAHE function from skimage
             result = skimage.exposure.equalize_adapthist(da.values, **kwargs)
-            #new_coords = {k: v for k, v in da.coords.items() if k != 'band' or len(v) == 3}
+            # new_coords = {k: v for k, v in da.coords.items() if k != 'band' or len(v) == 3}
 
             # Convert the result back to a DataArray, preserving the original metadata
             return xr.DataArray(result, dims=da.dims, coords=da.coords, attrs=da.attrs)
-        
+
         rgb_da = self.rgb
-        
-        #template = rgb_da.copy(data=np.empty_like(rgb_da).data)
+
+        # template = rgb_da.copy(data=np.empty_like(rgb_da).data)
         template = xr.zeros_like(rgb_da)
-        rgb_clahe_da = xr.map_blocks(equalize_adapthist_da, rgb_da, template=template, kwargs=kwargs)
-        rgb_clahe_da = rgb_clahe_da.where(self.data.scl>=0)
+        rgb_clahe_da = xr.map_blocks(
+            equalize_adapthist_da, rgb_da, template=template, kwargs=kwargs
+        )
+        rgb_clahe_da = rgb_clahe_da.where(self.data.scl >= 0)
 
         return rgb_clahe_da
 
@@ -1702,11 +1820,11 @@ class Sentinel1:
         end_date=today,
         catalog_choice="planetarycomputer",
         bands=None,
-        units='dB', # linear power or dB
+        units="dB",  # linear power or dB
         resolution=None,
         crs=None,
         groupby="sat:absolute_orbit",
-        chunks={}, # {"x": 512, "y": 512} or # {"x": 512, "y": 512, "time": -1}
+        chunks={},  # {"x": 512, "y": 512} or # {"x": 512, "y": 512, "time": -1}
         remove_border_noise=True,
     ):
         """
@@ -1734,7 +1852,7 @@ class Sentinel1:
         self.groupby = groupby
         self.remove_border_noise = remove_border_noise
 
-        #if not self.geobox:
+        # if not self.geobox:
         self.bbox_gdf = convert_bbox_to_geodataframe(self.bbox_input)
 
         if self.crs is None:
@@ -1754,10 +1872,12 @@ class Sentinel1:
         if self.remove_border_noise:
             self.remove_bad_scenes_and_border_noise()
         self.add_orbit_info()
-        if units == 'dB':
+        if units == "dB":
             self.linear_to_db()
         else:
-            print('Units remain in linear power. Convert to dB using the .linear_to_db() method.')
+            print(
+                "Units remain in linear power. Convert to dB using the .linear_to_db() method."
+            )
 
     def search_data(self):
         """
@@ -1844,18 +1964,18 @@ class Sentinel1:
     #     print(f"Border noise removed from the data.")
 
     def remove_bad_scenes_and_border_noise(self, threshold=0.001):
-        cutoff_date = np.datetime64('2018-03-14')
-        
+        cutoff_date = np.datetime64("2018-03-14")
+
         original_crs = self.data.rio.crs
-        
+
         result = xr.where(
             self.data.time < cutoff_date,
             self.data.where(self.data > threshold),
-            self.data.where(self.data > 0)
+            self.data.where(self.data > 0),
         )
-        
+
         result.rio.write_crs(original_crs, inplace=True)
-        
+
         self.data = result
         print(f"Falsely low scenes and border noise removed from the data.")
 
@@ -1905,15 +2025,15 @@ class Sentinel1:
     def local_incidence_angle_data(self):
         """
         Property to access local incidence angle data.
-        
+
         Returns
         -------
         xarray.DataArray
             DataArray containing local incidence angle values aligned to the same grid as the primary data.
-            
+
         Notes
         -----
-        On first access, this property calculates local incidence angles using Sentinel-1 data and 
+        On first access, this property calculates local incidence angles using Sentinel-1 data and
         Copernicus 30m DEM. Results are cached for subsequent accesses.
         """
         if self._local_incidence_angle_data is None:
@@ -1931,13 +2051,13 @@ class Sentinel1:
             Desired resolution in meters for the calculation. Defaults to self.resolution if set, or 30m.
         initialize_ee : bool, optional
             Whether to initialize Earth Engine. Default is True.
-            
+
         Returns
         -------
         xarray.DataArray
             DataArray containing local incidence angle values with dimensions (sat:relative_orbit, y, x),
             aligned to the same grid as the primary data.
-            
+
         Notes
         -----
         Requires Google Earth Engine authentication. Run ``ee.Authenticate()`` and
@@ -1956,224 +2076,254 @@ class Sentinel1:
 
         # Initialize Earth Engine with high-volume endpoint
         if initialize_ee:
-            ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com')
+            ee.Initialize(opt_url="https://earthengine-highvolume.googleapis.com")
         else:
-            _logger.info("Earth Engine initialization skipped. Ensure EE is already initialized.")
+            _logger.info(
+                "Earth Engine initialization skipped. Ensure EE is already initialized."
+            )
 
         # Convert bbox to Earth Engine geometry
         bbox = tuple(self.bbox_gdf.total_bounds)
         ee_bbox = ee.Geometry.Rectangle(bbox)
-        
+
         # Filter Sentinel-1 collection
-        collection = ee.ImageCollection('COPERNICUS/S1_GRD') \
-            .filterBounds(ee_bbox) \
-            .filter(ee.Filter.listContains('transmitterReceiverPolarisation', 'VV')) \
-            .filter(ee.Filter.eq('instrumentMode', 'IW'))
-        
+        collection = (
+            ee.ImageCollection("COPERNICUS/S1_GRD")
+            .filterBounds(ee_bbox)
+            .filter(ee.Filter.listContains("transmitterReceiverPolarisation", "VV"))
+            .filter(ee.Filter.eq("instrumentMode", "IW"))
+        )
+
         # Get distinct orbit numbers
-        distinct_orbits = collection.aggregate_array('relativeOrbitNumber_start').distinct()
+        distinct_orbits = collection.aggregate_array(
+            "relativeOrbitNumber_start"
+        ).distinct()
         orbit_list = distinct_orbits.getInfo()
-        
+
         if not orbit_list:
             raise ValueError("No Sentinel-1 data found for the specified bounding box.")
-        
+
         print(f"Found {len(orbit_list)} unique relative orbits: {orbit_list}")
-        
+
         # Find the most common projection among the orbits
         orbit_projections = {}
         print("Analyzing orbit projections to find the most common one...")
-        
+
         for orbit in orbit_list:
-            orbit_image = collection \
-                .filter(ee.Filter.eq('relativeOrbitNumber_start', orbit)) \
-                .first()
-            
+            orbit_image = collection.filter(
+                ee.Filter.eq("relativeOrbitNumber_start", orbit)
+            ).first()
+
             if orbit_image:
                 # Get projection info
                 proj_info = orbit_image.select(0).projection().getInfo()
-                crs = proj_info['crs']
+                crs = proj_info["crs"]
                 orbit_projections[orbit] = {
-                    'crs': crs,
-                    'transform': proj_info['transform']
+                    "crs": crs,
+                    "transform": proj_info["transform"],
                 }
                 print(f"Orbit {orbit} uses {crs}")
-        
+
         # Count CRS frequencies
-        crs_counts = Counter([info['crs'] for info in orbit_projections.values()])
+        crs_counts = Counter([info["crs"] for info in orbit_projections.values()])
         most_common_crs = crs_counts.most_common(1)[0][0]
-        
-        print(f"Most common CRS: {most_common_crs} (used by {crs_counts[most_common_crs]} of {len(orbit_list)} orbits)")
-        
+
+        print(
+            f"Most common CRS: {most_common_crs} (used by {crs_counts[most_common_crs]} of {len(orbit_list)} orbits)"
+        )
+
         # Function to calculate local incidence angle using Copernicus 30m DEM
         def calculate_local_incidence_angle(image):
             img_geom = image.geometry()
-            
+
             # Use Copernicus 30m DEM with proper reprojection
-            dem_collection = ee.ImageCollection('COPERNICUS/DEM/GLO30')
-            dem = dem_collection.select('DEM').mosaic().clip(img_geom)
-            
+            dem_collection = ee.ImageCollection("COPERNICUS/DEM/GLO30")
+            dem = dem_collection.select("DEM").mosaic().clip(img_geom)
+
             # Reproject DEM to the most common CRS with the specified resolution
             projection = ee.Projection(most_common_crs).atScale(calc_resolution)
             dem = dem.reproject(projection)
-            
-            # 2.1.1 Radar geometry 
-            theta_i = image.select('angle')
-            phi_i = ee.Terrain.aspect(theta_i) \
-                .reduceRegion(ee.Reducer.mean(), theta_i.get('system:footprint'), 1000) \
-                .get('aspect')
-            
+
+            # 2.1.1 Radar geometry
+            theta_i = image.select("angle")
+            phi_i = (
+                ee.Terrain.aspect(theta_i)
+                .reduceRegion(ee.Reducer.mean(), theta_i.get("system:footprint"), 1000)
+                .get("aspect")
+            )
+
             # 2.1.2 Terrain geometry
-            alpha_s = ee.Terrain.slope(dem).select('slope')
-            phi_s = ee.Terrain.aspect(dem).select('aspect')
-            
+            alpha_s = ee.Terrain.slope(dem).select("slope")
+            phi_s = ee.Terrain.aspect(dem).select("aspect")
+
             # 2.1.3 Model geometry
             # reduce to 3 angle
             phi_r = ee.Image.constant(phi_i).subtract(phi_s)
-            
+
             # convert all to radians
             phi_rRad = phi_r.multiply(math.pi / 180)
             alpha_sRad = alpha_s.multiply(math.pi / 180)
             theta_iRad = theta_i.multiply(math.pi / 180)
             ninetyRad = ee.Image.constant(90).multiply(math.pi / 180)
-            
+
             # slope steepness in range (eq. 2)
             alpha_r = (alpha_sRad.tan().multiply(phi_rRad.cos())).atan()
-            
+
             # slope steepness in azimuth (eq 3)
             alpha_az = (alpha_sRad.tan().multiply(phi_rRad.sin())).atan()
-            
+
             # local incidence angle (eq. 4)
-            cos_theta_lia = (alpha_az.cos().multiply((theta_iRad.subtract(alpha_r)).cos()))
-            
+            cos_theta_lia = alpha_az.cos().multiply(
+                (theta_iRad.subtract(alpha_r)).cos()
+            )
+
             # Ensure valid range for acos
             cos_theta_lia = cos_theta_lia.clamp(-1, 1)
-            
+
             theta_lia = cos_theta_lia.acos()
             theta_liaDeg = theta_lia.multiply(180 / math.pi)
-            
-            return image.addBands(theta_liaDeg.rename('local_incidence_angle'))
-        
+
+            return image.addBands(theta_liaDeg.rename("local_incidence_angle"))
+
         # Create list to store DataArrays for each orbit
         orbit_arrays = []
-        
+
         # Create standard projection based on the most common CRS
         standard_projection = ee.Projection(most_common_crs).atScale(calc_resolution)
-        
+
         # Process each orbit
         for orbit in orbit_list:
             # Get images for this orbit
-            orbit_images = collection \
-                .filter(ee.Filter.eq('relativeOrbitNumber_start', orbit)) \
-                .sort('system:time_start', True) \
+            orbit_images = (
+                collection.filter(ee.Filter.eq("relativeOrbitNumber_start", orbit))
+                .sort("system:time_start", True)
                 .limit(3)
-            
+            )
+
             if orbit_images.size().getInfo() > 0:
                 # Calculate LIA for each image
                 lia_images = orbit_images.map(calculate_local_incidence_angle)
-                
+
                 # Calculate median LIA
-                median_lia = lia_images.select('local_incidence_angle').median()
-                
+                median_lia = lia_images.select("local_incidence_angle").median()
+
                 # Set properties on the median image
-                timestamp = orbit_images.first().get('system:time_start')
-                median_lia = median_lia.set({
-                    'relativeOrbitNumber_start': orbit,
-                    'system:time_start': timestamp
-                })
-                
+                timestamp = orbit_images.first().get("system:time_start")
+                median_lia = median_lia.set(
+                    {"relativeOrbitNumber_start": orbit, "system:time_start": timestamp}
+                )
+
                 # Create a single-image collection for xee
                 orbit_collection = ee.ImageCollection([median_lia])
-                
+
                 # Use xee to convert to xarray
                 try:
                     ds = xr.open_dataset(
-                        orbit_collection, 
-                        engine='ee',
+                        orbit_collection,
+                        engine="ee",
                         geometry=bbox,
                         projection=standard_projection,
                         chunks={},
                     )
-                    
+
                     # Extract the DataArray
-                    da = ds['local_incidence_angle']
-                    
+                    da = ds["local_incidence_angle"]
+
                     # Remove the time dimension if present
-                    if 'time' in da.dims:
+                    if "time" in da.dims:
                         da = da.isel(time=0, drop=True)
-                    
+
                     # Add orbit as a coordinate
-                    da = da.assign_coords({'sat:relative_orbit': orbit})
-                    
+                    da = da.assign_coords({"sat:relative_orbit": orbit})
+
                     # Check for NaN values
                     nan_percentage = np.isnan(da.values).mean() * 100
-                    print(f"Orbit {orbit} - Shape: {da.shape}, NaN percentage: {nan_percentage:.1f}%")
-                    
+                    print(
+                        f"Orbit {orbit} - Shape: {da.shape}, NaN percentage: {nan_percentage:.1f}%"
+                    )
+
                     if nan_percentage < 100:  # Only keep arrays with some valid data
                         # Store in list
                         orbit_arrays.append(da)
                         print(f"Successfully processed orbit {orbit}")
                     else:
                         print(f"Skipping orbit {orbit} - all values are NaN")
-                        
+
                 except Exception as e:
                     print(f"Error processing orbit {orbit}: {e}")
-        
+
         if orbit_arrays:
             # Ensure all arrays have the same shape before concatenating
             shapes = [da.shape for da in orbit_arrays]
             if len(set(shapes)) > 1:
                 print(f"Warning: Arrays have different shapes: {shapes}")
-                
+
                 # Take the shape with the most non-NaN values as template
-                best_da_idx = np.argmax([~np.isnan(da.values).sum() for da in orbit_arrays])
+                best_da_idx = np.argmax(
+                    [~np.isnan(da.values).sum() for da in orbit_arrays]
+                )
                 template_da = orbit_arrays[best_da_idx]
-                
+
                 for i in range(len(orbit_arrays)):
                     if i != best_da_idx and orbit_arrays[i].shape != template_da.shape:
                         orbit_num = orbit_arrays[i].sat_relative_orbit.values[0]
-                        print(f"Resampling orbit {orbit_num} to match template shape {template_da.shape}")
+                        print(
+                            f"Resampling orbit {orbit_num} to match template shape {template_da.shape}"
+                        )
                         orbit_arrays[i] = orbit_arrays[i].reindex_like(template_da)
-            
-            # Combine all orbits into a single DataArray
-            lia_da = xr.concat(orbit_arrays, dim='sat:relative_orbit')
-            
-            # Add attributes
-            lia_da.attrs.update({
-                'long_name': 'Sentinel-1 Local Incidence Angle',
-                'units': 'degrees',
-                'description': 'Local incidence angle calculated from Sentinel-1 data and Copernicus 30m DEM',
-                'source': 'Sentinel-1 GRD'
-            })
 
-            lia_da = lia_da.transpose("sat:relative_orbit",'Y','X').rename({'X':'x', 'Y':'y'}).rio.set_spatial_dims(x_dim='x', y_dim='y')
-            lia_da = lia_da.sortby('sat:relative_orbit')
+            # Combine all orbits into a single DataArray
+            lia_da = xr.concat(orbit_arrays, dim="sat:relative_orbit")
+
+            # Add attributes
+            lia_da.attrs.update(
+                {
+                    "long_name": "Sentinel-1 Local Incidence Angle",
+                    "units": "degrees",
+                    "description": "Local incidence angle calculated from Sentinel-1 data and Copernicus 30m DEM",
+                    "source": "Sentinel-1 GRD",
+                }
+            )
+
+            lia_da = (
+                lia_da.transpose("sat:relative_orbit", "Y", "X")
+                .rename({"X": "x", "Y": "y"})
+                .rio.set_spatial_dims(x_dim="x", y_dim="y")
+            )
+            lia_da = lia_da.sortby("sat:relative_orbit")
             # should be in range from 0 to 90
-            #lia_da = lia_da.where(lambda x: (x >= 0) & (x <= 90))
-            
+            # lia_da = lia_da.where(lambda x: (x >= 0) & (x <= 90))
+
             # Reproject to match data grid exactly using bilinear interpolation
             if self.data is not None:
                 # Get reference grid from first data variable
                 ref_da = self.data[list(self.data.data_vars)[0]].isel(time=0)
-                
+
                 # Ensure lia_da has CRS information
                 if not lia_da.rio.crs and ref_da.rio.crs:
                     lia_da.rio.write_crs(ref_da.rio.crs, inplace=True)
-                
+
                 # Reproject to match data grid using bilinear interpolation, careful with nodata
                 lia_da = lia_da.rio.reproject_match(
                     ref_da,
                     resampling=rio.warp.Resampling.bilinear,
                     nodata=np.nan,
                 )
-                
-                print("Local incidence angle data reprojected to match main data grid using bilinear resampling.")
-            
+
+                print(
+                    "Local incidence angle data reprojected to match main data grid using bilinear resampling."
+                )
+
             self._local_incidence_angle_data = lia_da
-            print("Local incidence angle calculation complete. Access via the .local_incidence_angle_data attribute.")
-            
-            #return self._local_incidence_angle_data
+            print(
+                "Local incidence angle calculation complete. Access via the .local_incidence_angle_data attribute."
+            )
+
+            # return self._local_incidence_angle_data
         else:
-            raise ValueError("No valid Sentinel-1 data found for the specified bounding box.")
+            raise ValueError(
+                "No valid Sentinel-1 data found for the specified bounding box."
+            )
 
 
 class HLS:
@@ -2302,7 +2452,7 @@ class HLS:
             self.crs = self.bbox_gdf.estimate_utm_crs()
 
         # Define the band information
-        self.band_info = { # https://github.com/stac-extensions/eo#common-band-names
+        self.band_info = {  # https://github.com/stac-extensions/eo#common-band-names
             "coastal": {
                 "landsat_band": "B01",
                 "sentinel_band": "B01",
@@ -2600,17 +2750,20 @@ class HLS:
         """
         The method to remove no data values from the data.
         """
-        data_removed=False
+        data_removed = False
         for band in self.data.data_vars:
             nodata_value = self.data[band].attrs.get("nodata")
             if nodata_value is not None:
                 self.data[band] = self.data[band].where(self.data[band] != nodata_value)
-                data_removed=True
+                data_removed = True
         if data_removed:
-            print(f"Nodata values removed from the data. In doing so, all bands converted to float32. To turn this behavior off, set remove_nodata=False.")
+            print(
+                f"Nodata values removed from the data. In doing so, all bands converted to float32. To turn this behavior off, set remove_nodata=False."
+            )
         else:
-            print(f"Tried to remove nodata values and set them to nans, but no nodata values found in the data.")
-
+            print(
+                f"Tried to remove nodata values and set them to nans, but no nodata values found in the data."
+            )
 
     def mask_data(
         self,
@@ -2854,8 +3007,11 @@ class HLS:
 
     #     print(f"RGB data retrieved. Access with the .rgb attribute.")
 
-
-    def get_rgb(self, percentile_kwargs={'lower': 2, 'upper': 98}, clahe_kwargs={'clip_limit': 0.03, 'nbins': 256, 'kernel_size': None}):
+    def get_rgb(
+        self,
+        percentile_kwargs={"lower": 2, "upper": 98},
+        clahe_kwargs={"clip_limit": 0.03, "nbins": 256, "kernel_size": None},
+    ):
         """
         Retrieve RGB data with optional percentile-based contrast stretching and CLAHE enhancement.
 
@@ -2886,16 +3042,22 @@ class HLS:
         - .rgb_clahe: CLAHE-enhanced RGB data
         """
 
-        rgba_da = self.data.odc.to_rgba(bands=('red','green','blue'),vmin=-0.30, vmax=1.35)
+        rgba_da = self.data.odc.to_rgba(
+            bands=("red", "green", "blue"), vmin=-0.30, vmax=1.35
+        )
         self.rgba = rgba_da
 
-        rgb_da = rgba_da.isel(band=slice(0, 3)) # .where(self.data.scl>=0, other=255) if we want to make no data white
+        rgb_da = rgba_da.isel(
+            band=slice(0, 3)
+        )  # .where(self.data.scl>=0, other=255) if we want to make no data white
         self.rgb = rgb_da
 
         self.rgb_percentile = self.get_rgb_percentile(**percentile_kwargs)
         self.rgb_clahe = self.get_rgb_clahe(**clahe_kwargs)
 
-        print(f"RGB data retrieved.\nAccess with the following attributes:\n.rgb for raw RGB,\n.rgba for RGBA,\n.rgb_percentile for percentile RGB,\n.rgb_clahe for CLAHE RGB.\nYou can pass in percentile_kwargs and clahe_kwargs to adjust RGB calculations, check documentation for options.")
+        print(
+            f"RGB data retrieved.\nAccess with the following attributes:\n.rgb for raw RGB,\n.rgba for RGBA,\n.rgb_percentile for percentile RGB,\n.rgb_clahe for CLAHE RGB.\nYou can pass in percentile_kwargs and clahe_kwargs to adjust RGB calculations, check documentation for options."
+        )
 
     def get_rgb_percentile(self, **percentile_kwargs):
         """
@@ -2919,21 +3081,23 @@ class HLS:
         -----
         The function clips values to the range [0, 1] and masks areas where SCL < 0.
         """
-        lower_percentile = percentile_kwargs.get('lower', 2)
-        upper_percentile = percentile_kwargs.get('upper', 98)
+        lower_percentile = percentile_kwargs.get("lower", 2)
+        upper_percentile = percentile_kwargs.get("upper", 98)
 
         def stretch_percentile(da):
-            p_low, p_high = np.nanpercentile(da.values, [lower_percentile, upper_percentile])
+            p_low, p_high = np.nanpercentile(
+                da.values, [lower_percentile, upper_percentile]
+            )
             return (da - p_low) / (p_high - p_low)
 
-        rgb_da = self.rgb.where(self.rgba.isel(band=-1)==255)
-        
+        rgb_da = self.rgb.where(self.rgba.isel(band=-1) == 255)
+
         template = xr.zeros_like(rgb_da)
         rgb_percentile_da = xr.map_blocks(stretch_percentile, rgb_da, template=template)
-        rgb_percentile_da = rgb_percentile_da.clip(0, 1)#.where(self.data.scl>=0)
+        rgb_percentile_da = rgb_percentile_da.clip(0, 1)  # .where(self.data.scl>=0)
 
         return rgb_percentile_da
-    
+
     def get_rgb_clahe(self, **kwargs):
         """
         Apply Contrast Limited Adaptive Histogram Equalization (CLAHE) to RGB bands.
@@ -2963,17 +3127,21 @@ class HLS:
         def equalize_adapthist_da(da, **kwargs):
             # Apply the CLAHE function from skimage
             result = skimage.exposure.equalize_adapthist(da.values, **kwargs)
-            #new_coords = {k: v for k, v in da.coords.items() if k != 'band' or len(v) == 3}
+            # new_coords = {k: v for k, v in da.coords.items() if k != 'band' or len(v) == 3}
 
             # Convert the result back to a DataArray, preserving the original metadata
             return xr.DataArray(result, dims=da.dims, coords=da.coords, attrs=da.attrs)
-        
+
         rgb_da = self.rgb
-        
-        #template = rgb_da.copy(data=np.empty_like(rgb_da).data)
+
+        # template = rgb_da.copy(data=np.empty_like(rgb_da).data)
         template = xr.zeros_like(rgb_da)
-        rgb_clahe_da = xr.map_blocks(equalize_adapthist_da, rgb_da, template=template, kwargs=kwargs)
-        rgb_clahe_da = rgb_clahe_da.where(self.rgba.isel(band=-1)==255)#.where(self.data.scl>=0)
+        rgb_clahe_da = xr.map_blocks(
+            equalize_adapthist_da, rgb_da, template=template, kwargs=kwargs
+        )
+        rgb_clahe_da = rgb_clahe_da.where(
+            self.rgba.isel(band=-1) == 255
+        )  # .where(self.data.scl>=0)
 
         return rgb_clahe_da
 
@@ -3144,7 +3312,6 @@ class MODIS_snow:
     def get_data(self):
 
         if self.data_product == "MOD10A1" or self.data_product == "MOD10A2":
-
             load_params = {
                 "items": self.search.item_collection(),
                 "chunks": {"time": 1, "x": 512, "y": 512},
@@ -3176,7 +3343,6 @@ class MODIS_snow:
                 self.search, temp_download_fp
             )  # can i suppress the print output? https://earthaccess.readthedocs.io/en/latest/user-reference/api/api/
 
-
             if self.clip_to_bbox:
                 modis_snow = xr.concat(
                     [
@@ -3184,7 +3350,9 @@ class MODIS_snow:
                             file, variable="CGF_NDSI_Snow_Cover", chunks={}
                         )["CGF_NDSI_Snow_Cover"]
                         .squeeze()
-                        .rio.clip_box(*self.bbox_gdf.total_bounds,crs=self.bbox_gdf.crs)
+                        .rio.clip_box(
+                            *self.bbox_gdf.total_bounds, crs=self.bbox_gdf.crs
+                        )
                         .assign_coords(
                             time=pd.to_datetime(
                                 rxr.open_rasterio(
@@ -3249,14 +3417,12 @@ class MODIS_snow:
     def get_binary_snow(self):
 
         if self.data_product == "MOD10A2":
-            self.binary_snow = xr.where(self.data["Maximum_Snow_Extent"] == 200, 1, 0).rio.write_crs(self.data.rio.crs)
+            self.binary_snow = xr.where(
+                self.data["Maximum_Snow_Extent"] == 200, 1, 0
+            ).rio.write_crs(self.data.rio.crs)
             print("Binary snow map calculated. Access with the .binary_snow attribute.")
         else:
             print("This method is only available for the MOD10A2 product.")
-
-
-
-
 
 
 # palsar2

--- a/easysnowdata/topography.py
+++ b/easysnowdata/topography.py
@@ -21,7 +21,11 @@ import xarray as xr
 
 odc.stac.configure_rio(cloud_defaults=True)
 
-from easysnowdata.utils import convert_bbox_to_geodataframe, get_stac_cfg, requires_earthengine
+from easysnowdata.utils import (
+    convert_bbox_to_geodataframe,
+    get_stac_cfg,
+    requires_earthengine,
+)
 
 __all__ = ["get_copernicus_dem", "get_chili"]
 
@@ -29,7 +33,10 @@ _logger = logging.getLogger(__name__)
 
 
 def get_copernicus_dem(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
     resolution: int = 30,
 ) -> xr.DataArray:
     """Fetch the Copernicus Global DEM for a bounding box.
@@ -76,9 +83,9 @@ def get_copernicus_dem(
     search = catalog.search(
         collections=[f"cop-dem-glo-{resolution}"], bbox=bbox_gdf.total_bounds
     )
-    cop_dem_da = odc.stac.load(
-        search.items(), bbox=bbox_gdf.total_bounds, chunks={}
-    )["data"].squeeze()
+    cop_dem_da = odc.stac.load(search.items(), bbox=bbox_gdf.total_bounds, chunks={})[
+        "data"
+    ].squeeze()
     cop_dem_da = cop_dem_da.rio.write_nodata(-32767, encoded=True)
 
     cop_dem_da.attrs["data_citation"] = (
@@ -91,7 +98,10 @@ def get_copernicus_dem(
 
 @requires_earthengine
 def get_chili(
-    bbox_input: gpd.GeoDataFrame | tuple | shapely.geometry.base.BaseGeometry | None = None,
+    bbox_input: gpd.GeoDataFrame
+    | tuple
+    | shapely.geometry.base.BaseGeometry
+    | None = None,
     initialize_ee: bool = True,
 ) -> xr.DataArray:
     """Fetch CHILI (Continuous Heat-Insolation Load Index) for a bounding box.

--- a/easysnowdata/utils.py
+++ b/easysnowdata/utils.py
@@ -75,12 +75,14 @@ Register for a free account at: https://urs.earthdata.nasa.gov"""
 
 # ── Credential detection ──────────────────────────────────────────────────────
 
+
 def _has_earthengine_credentials() -> bool:
     """Return True if EE credentials can be found (env var or credential file)."""
     if os.environ.get("EARTHENGINE_TOKEN"):
         return True
     try:
         import ee  # noqa: PLC0415
+
         creds_path = Path(ee.oauth.get_credentials_path())
         return creds_path.exists()
     except Exception:
@@ -102,8 +104,10 @@ def _has_earthaccess_credentials() -> bool:
 
 # ── Auth decorators ───────────────────────────────────────────────────────────
 
+
 def requires_earthengine(func):
     """Decorator: raise CredentialError with setup instructions if EE credentials are missing."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if not _has_earthengine_credentials():
@@ -111,11 +115,13 @@ def requires_earthengine(func):
                 f"`{func.__qualname__}` requires Google Earth Engine.\n\n{_EE_SETUP_MSG}"
             )
         return func(*args, **kwargs)
+
     return wrapper
 
 
 def requires_earthaccess(func):
     """Decorator: raise CredentialError with setup instructions if EarthData credentials are missing."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         if not _has_earthaccess_credentials():
@@ -123,6 +129,7 @@ def requires_earthaccess(func):
                 f"`{func.__qualname__}` requires NASA EarthData credentials.\n\n{_EARTHACCESS_SETUP_MSG}"
             )
         return func(*args, **kwargs)
+
     return wrapper
 
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "easysnowdata"
-version = "0.0.21"
+version = "0.0.22"
 description = "A Python package to easily retrieve data relevant to snow science"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "easysnowdata"
 version = "0.0.21"
 description = "A Python package to easily retrieve data relevant to snow science"
@@ -47,7 +47,7 @@ mkdocstrings = "*"
 mkdocstrings-python = "*"
 pygments = "*"
 pymdown-extensions = "*"
-build = "*"
+python-build = "*"
 bump-my-version = "*"
 twine = "*"
 codespell = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "easysnowdata"
-version = "0.0.21"
+version = "0.0.22"
 description = "A Python package to easily retrieve data relevant to snow science"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -55,7 +55,7 @@ include = ["easysnowdata*"]
 exclude = ["docs*", "tests*", "scripts*"]
 
 [tool.bumpversion]
-current_version = "0.0.21"
+current_version = "0.0.22"
 commit = true
 tag = true
 

--- a/scripts/check_data_sources.py
+++ b/scripts/check_data_sources.py
@@ -88,6 +88,7 @@ def _check(
 # Individual source checks
 # ---------------------------------------------------------------------------
 
+
 def check_snotel_station_list() -> None:
     url = "https://github.com/egagli/snotel_ccss_stations/raw/main/all_stations.geojson"
     ok, reason = _head_ok(url)
@@ -297,15 +298,30 @@ CHECKS: list[dict] = [
     {"name": "SNOTEL/CCSS station list (GitHub)", "fn": check_snotel_station_list},
     {"name": "SNOTEL/CCSS station CSV (GitHub)", "fn": check_snotel_single_csv},
     {"name": "HydroATLAS basins (figshare)", "fn": check_hydroatlas_figshare},
-    {"name": "GRDC major river basins (World Bank)", "fn": check_grdc_major_river_basins},
+    {
+        "name": "GRDC major river basins (World Bank)",
+        "fn": check_grdc_major_river_basins,
+    },
     {"name": "GRDC WMO basins", "fn": check_grdc_wmo_basins},
-    {"name": "Köppen-Geiger classification (figshare)", "fn": check_koppen_geiger_figshare},
-    {"name": "Sturm & Liston snow classification (Azure)", "fn": check_snow_classification_azure},
+    {
+        "name": "Köppen-Geiger classification (figshare)",
+        "fn": check_koppen_geiger_figshare,
+    },
+    {
+        "name": "Sturm & Liston snow classification (Azure)",
+        "fn": check_snow_classification_azure,
+    },
     {"name": "Forest cover fraction (Zenodo)", "fn": check_forest_cover_zenodo},
     {"name": "Mountain snow mask (Zenodo)", "fn": check_mountain_snow_mask_zenodo},
     {"name": "ARCO-ERA5 (GCS anonymous)", "fn": check_arco_era5_gcs},
-    {"name": "Copernicus DEM (Planetary Computer)", "fn": check_copernicus_dem_planetary_computer},
-    {"name": "ESA WorldCover (Planetary Computer)", "fn": check_esa_worldcover_planetary_computer},
+    {
+        "name": "Copernicus DEM (Planetary Computer)",
+        "fn": check_copernicus_dem_planetary_computer,
+    },
+    {
+        "name": "ESA WorldCover (Planetary Computer)",
+        "fn": check_esa_worldcover_planetary_computer,
+    },
     # GEE-credential checks
     {
         "name": "HUC geometries (GEE/USGS WBD)",

--- a/scripts/update_readme_status.py
+++ b/scripts/update_readme_status.py
@@ -100,7 +100,9 @@ def update_readme(table: str, readme_path: Path) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Update README data-source status table.")
+    parser = argparse.ArgumentParser(
+        description="Update README data-source status table."
+    )
     parser.add_argument("--history", default="data_status/history.json")
     parser.add_argument("--readme", default="README.md")
     args = parser.parse_args()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,10 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_runtest_setup(item: pytest.Item) -> None:
     for _ in item.iter_markers("requires_earthengine"):
         if not os.getenv("EARTHENGINE_TOKEN"):
-            pytest.skip(
-                "Skipping: EARTHENGINE_TOKEN environment variable is not set."
-            )
+            pytest.skip("Skipping: EARTHENGINE_TOKEN environment variable is not set.")
     for _ in item.iter_markers("requires_earthaccess"):
         if not (os.getenv("EARTHDATA_USERNAME") and os.getenv("EARTHDATA_PASSWORD")):
-            pytest.skip(
-                "Skipping: EARTHDATA_USERNAME / EARTHDATA_PASSWORD not set."
-            )
+            pytest.skip("Skipping: EARTHDATA_USERNAME / EARTHDATA_PASSWORD not set.")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -11,7 +11,7 @@ def create_ee_credentials():
     """Create Earth Engine credentials from environment token"""
     if not os.getenv("EARTHENGINE_TOKEN"):
         raise pytest.skip("EARTHENGINE_TOKEN environment variable not set")
-    
+
     stored = json.loads(os.getenv("EARTHENGINE_TOKEN"))
     return google.oauth2.credentials.Credentials(
         None,
@@ -22,36 +22,38 @@ def create_ee_credentials():
         quota_project_id=stored["project"],
     )
 
+
 @pytest.fixture
 def ee_credentials():
     """Fixture to setup Earth Engine credentials"""
     return create_ee_credentials()
+
 
 class TestEarthEngine:
     def test_ee_initialization(self, ee_credentials):
         """Test Earth Engine initializes successfully"""
         ee.Initialize(credentials=ee_credentials)
         assert ee.data._credentials is not None
-    
+
     def test_ee_api_connection(self, ee_credentials):
         """Test Earth Engine API connection works"""
         ee.Initialize(credentials=ee_credentials)
         response = ee.String("Greetings from the Earth Engine servers!").getInfo()
         assert isinstance(response, str)
         assert "Greetings" in response
-    
+
     def test_missing_token(self, monkeypatch):
         """Test handling of missing environment variable"""
         monkeypatch.delenv("EARTHENGINE_TOKEN", raising=False)
         with pytest.raises(pytest.skip.Exception):
             create_ee_credentials()
-    
+
     def test_invalid_token(self, monkeypatch):
         """Test handling of invalid token"""
         monkeypatch.setenv("EARTHENGINE_TOKEN", '{"invalid": "token"}')
         with pytest.raises(KeyError):
             create_ee_credentials()
-            
+
 
 # https://github.com/gee-community/ee-initialize-github-actions?tab=readme-ov-file#4-initialize-to-earth-engine-in-your-test-file
 # import ee

--- a/tests/test_easysnowdata.py
+++ b/tests/test_easysnowdata.py
@@ -24,7 +24,13 @@ def test_version_is_string():
 
 def test_public_api_surface():
     """Verify __all__ entries are importable from each module."""
-    from easysnowdata import automatic_weather_stations, hydroclimatology, remote_sensing, topography, utils
+    from easysnowdata import (
+        automatic_weather_stations,
+        hydroclimatology,
+        remote_sensing,
+        topography,
+        utils,
+    )
 
     for name in utils.__all__:
         assert hasattr(utils, name), f"utils.{name} missing"

--- a/tests/test_hydroclimatology.py
+++ b/tests/test_hydroclimatology.py
@@ -73,7 +73,9 @@ class TestKoppenGeiger:
 # ---------------------------------------------------------------------------
 class TestGrdcMajorRiverBasins:
     def test_returns_geodataframe(self):
-        from easysnowdata.hydroclimatology import get_grdc_major_river_basins_of_the_world
+        from easysnowdata.hydroclimatology import (
+            get_grdc_major_river_basins_of_the_world,
+        )
 
         result = get_grdc_major_river_basins_of_the_world(bbox_input=TEST_BBOX)
         assert isinstance(result, gpd.GeoDataFrame)

--- a/tests/test_topography.py
+++ b/tests/test_topography.py
@@ -59,6 +59,7 @@ class TestChili:
 
         result = get_chili(bbox_input=TEST_BBOX)
         import numpy as np
+
         valid = result.values[~np.isnan(result.values)]
         assert valid.min() >= 0.0
         assert valid.max() <= 1.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,7 +117,9 @@ class TestCredentialError:
         assert callable(easysnowdata.authenticate_all)
 
     def test_requires_earthengine_decorator_blocks_without_creds(self, monkeypatch):
-        monkeypatch.setattr("easysnowdata.utils._has_earthengine_credentials", lambda: False)
+        monkeypatch.setattr(
+            "easysnowdata.utils._has_earthengine_credentials", lambda: False
+        )
 
         @requires_earthengine
         def fake_gee_func():
@@ -127,7 +129,9 @@ class TestCredentialError:
             fake_gee_func()
 
     def test_requires_earthengine_passes_with_creds(self, monkeypatch):
-        monkeypatch.setattr("easysnowdata.utils._has_earthengine_credentials", lambda: True)
+        monkeypatch.setattr(
+            "easysnowdata.utils._has_earthengine_credentials", lambda: True
+        )
 
         @requires_earthengine
         def fake_gee_func():
@@ -136,7 +140,9 @@ class TestCredentialError:
         assert fake_gee_func() == "ok"
 
     def test_requires_earthaccess_decorator_blocks_without_creds(self, monkeypatch):
-        monkeypatch.setattr("easysnowdata.utils._has_earthaccess_credentials", lambda: False)
+        monkeypatch.setattr(
+            "easysnowdata.utils._has_earthaccess_credentials", lambda: False
+        )
 
         @requires_earthaccess
         def fake_ea_func():
@@ -146,7 +152,9 @@ class TestCredentialError:
             fake_ea_func()
 
     def test_requires_earthaccess_passes_with_creds(self, monkeypatch):
-        monkeypatch.setattr("easysnowdata.utils._has_earthaccess_credentials", lambda: True)
+        monkeypatch.setattr(
+            "easysnowdata.utils._has_earthaccess_credentials", lambda: True
+        )
 
         @requires_earthaccess
         def fake_ea_func():


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

A broad quality pass across the whole repository — infrastructure, code quality, credential handling, tests, docs, and CI.

### Infrastructure & packaging
- Replace `requirements.txt` / `requirements_dev.txt` / `environment.yml` with a single `pixi.toml` (dev env only — users still `pip`/`conda` install as before)
- Inline all runtime dependencies into `pyproject.toml`; remove `dynamic = ["dependencies"]`
- Add `[tool.ruff]`, `[tool.pytest.ini_options]` with custom markers, and `bump-my-version` config to `pyproject.toml`
- Add `.pre-commit-config.yaml` (ruff, codespell, standard hooks)
- Bump to version **0.0.22**

### Code quality
- Replace `blockPrint()`/`enablePrint()` with a `suppress_stdout()` context manager in `utils.py`
- Replace all `print()` calls with `logging.getLogger(__name__)` throughout every module
- Add `__all__` lists and module-level docstrings to every module
- Full type hints on all public functions
- Apply `ruff format` across the entire codebase
- Remove empty placeholder `easysnowdata/easysnowdata.py`

### Credential handling (new)
- `CredentialError` — catchable exception with a multi-line setup message
- `@requires_earthengine` / `@requires_earthaccess` — decorators that check credentials before any processing and raise `CredentialError` with exact setup instructions
- `_has_earthengine_credentials()` / `_has_earthaccess_credentials()` — pure env-var + filesystem checks (no API calls); support `EARTHDATA_TOKEN` in addition to username/password
- Applied to all gated functions: `get_huc_geometries`, `get_snodas`, `get_chili`, `get_nlcd_landcover`, `get_ucla_snow_reanalysis`, `HLS`, `MODIS_snow` (MOD10A1F), `Sentinel1.get_local_incidence_angle`, `get_era5` (GEE branch)
- `easysnowdata.authenticate_all()` and `easysnowdata.CredentialError` surfaced at top-level namespace

### Tests
- New `tests/conftest.py` with `pytest.mark` skip decorators for `requires_earthengine` / `requires_earthaccess`
- Fully rewritten test files for all modules (pytest style, fixture-based)
- 33 credential-free tests passing; credential-gated tests skip gracefully when secrets are absent

### CI / GitHub Actions
- Consolidate 4 separate platform workflows into a single `ci.yml` matrix (Ubuntu × Python 3.10–3.13, macOS 3.12, Windows 3.12) with a separate `lint` job
- Add `data_source_health.yml`: weekly Monday 08:00 UTC health check across 18 data sources; rolling 4-week status table written back to `README.md`
- Fix `docs.yml` and `docs-build.yml` to install deps directly (no `requirements.txt`); remove stale `PKG-TEST` step
- Workflows now forward `EARTHENGINE_TOKEN`, `EARTHDATA_TOKEN`, `EARTHDATA_USERNAME`, `EARTHDATA_PASSWORD`
- Add CHANGELOG automation to `pypi.yml` release workflow

### Docs & README
- Overhaul `docs/index.md` with tabbed install, module table, 5-minute quickstart, credentials table, citation
- Restructure `mkdocs.yml` nav: Getting Started / User Guide / API Reference / Development
- Update `README.md`: preserve gallery GIF, add CI badge, data source status table (populated weekly), module overview, pixi dev install

## Test plan
- [ ] CI lint job passes (`ruff format --check` + `ruff check`)
- [ ] CI test matrix passes on Ubuntu 3.10–3.13 (credential-free tests)
- [ ] docs-build job builds MkDocs site without errors
- [ ] After merge: `pixi install -e dev` resolves cleanly on macOS arm64 and Linux
- [ ] After merge: trigger `data_source_health.yml` manually via workflow_dispatch to verify health check runs

https://claude.ai/code/session_017qL4K5x2cW9CTAQh6xCh5p
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017qL4K5x2cW9CTAQh6xCh5p)_